### PR TITLE
Application name endpoint

### DIFF
--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -39,6 +39,10 @@ public class UrlBuilder {
         return String.format("/ng/%s/applications?%s", organizationId, "base=false");
     }
 
+    public String getApplicationsNameUrl(String organizationId) {
+        return String.format("/ng/%s/applications/name?%s", organizationId, "base=false");
+    }
+
     public String getCoverageUrl(String organizationId, String appId) {
         return String.format("/ng/%s/applications/%s/coverage", organizationId, appId);
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -40,7 +40,7 @@ public class UrlBuilder {
     }
 
     public String getApplicationsNameUrl(String organizationId) {
-        return String.format("/ng/%s/applications/name?%s", organizationId, "base=false");
+        return String.format("/ng/%s/applications/name", organizationId);
     }
 
     public String getCoverageUrl(String organizationId, String appId) {

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -121,8 +121,6 @@ public class ContrastSDK {
         this.apiKey = apiKey;
         this.restApiURL = restApiURL;
 
-        this.restApiURL = restApiURL;
-
         ContrastSDKUtils.validateUrl(this.restApiURL);
         this.restApiURL = ContrastSDKUtils.ensureApi(this.restApiURL);
 

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -262,7 +262,19 @@ public class ContrastSDK {
         try {
             is = makeRequest(HttpMethod.GET, urlBuilder.getApplicationsUrl(organizationId));
             reader = new InputStreamReader(is);
+            return this.gson.fromJson(reader, Applications.class);
+        } finally {
+            IOUtils.closeQuietly(reader);
+            IOUtils.closeQuietly(is);
+        }
+    }
 
+    public Applications getApplicationsNames(String organizationId) throws UnauthorizedException, IOException {
+        InputStream is = null;
+        InputStreamReader reader = null;
+        try {
+            is = makeRequest(HttpMethod.GET, urlBuilder.getApplicationsNameUrl(organizationId));
+            reader = new InputStreamReader(is);
             return this.gson.fromJson(reader, Applications.class);
         } finally {
             IOUtils.closeQuietly(reader);
@@ -615,6 +627,6 @@ public class ContrastSDK {
     private static final int SERVER_ERROR = 500;
 
     private static final String DEFAULT_API_URL = "https://app.contrastsecurity.com/Contrast/api";
-    private static final String LOCALHOST_API_URL = "http://localhost:19080/Contrast/api";
+    private static final String LOCALHOST_API_URL = "http://localhost:19090/Contrast/api";
     private static final String DEFAULT_AGENT_PROFILE = "default";
 }

--- a/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
+++ b/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
@@ -36,10 +36,12 @@ public class ContrastSDKUtils {
     }
 
     public static String ensureApi(String url){
-        if(url.endsWith("/Contrast")){
-            url = url + "/api";
-        } else if( url.endsWith("/Contrast/")){
-            url = url + "api";
+        if(url != null) {
+            if (url.endsWith("/Contrast")) {
+                url = url + "/api";
+            } else if (url.endsWith("/Contrast/")) {
+                url = url + "api";
+            }
         }
         return url;
     }

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -92,32 +92,32 @@ public class ContrastSDKTest extends ContrastSDK {
         assertNotNull(servers);
         assertNotNull(servers.getServers());
     }
-    
+
     @Test
     public void setCustomTiemouts() throws IOException {
-    	final int connectionTimeout = 1000;
-    	final int readTimeout = 4000;
-    	contrastSDK.setConnectionTimeout(connectionTimeout);
-    	contrastSDK.setReadTimeout(readTimeout);
-    	
-    	URLConnection conn = contrastSDK.makeConnection("https://www.google.com", HttpMethod.GET.toString());
-    	
-    	assertEquals(connectionTimeout, conn.getConnectTimeout());
-    	assertEquals(readTimeout, conn.getReadTimeout());
+        final int connectionTimeout = 1000;
+        final int readTimeout = 4000;
+        contrastSDK.setConnectionTimeout(connectionTimeout);
+        contrastSDK.setReadTimeout(readTimeout);
+
+        URLConnection conn = contrastSDK.makeConnection("https://www.google.com", HttpMethod.GET.toString());
+
+        assertEquals(connectionTimeout, conn.getConnectTimeout());
+        assertEquals(readTimeout, conn.getReadTimeout());
     }
-    
+
     @Test
     public void negativeTimeoutsAreNotSetTest() throws IOException {
-    	final int connectionTimeout = -10;
-    	final int readTimeout = -50;
-    	
-    	contrastSDK.setConnectionTimeout(connectionTimeout);
-    	contrastSDK.setReadTimeout(readTimeout);
-    	
-    	URLConnection conn = contrastSDK.makeConnection("https://www.google.com", HttpMethod.GET.toString());
-    	
-    	assertNotEquals(connectionTimeout, conn.getConnectTimeout());
-    	assertNotEquals(readTimeout, conn.getReadTimeout());
+        final int connectionTimeout = -10;
+        final int readTimeout = -50;
+
+        contrastSDK.setConnectionTimeout(connectionTimeout);
+        contrastSDK.setReadTimeout(readTimeout);
+
+        URLConnection conn = contrastSDK.makeConnection("https://www.google.com", HttpMethod.GET.toString());
+
+        assertNotEquals(connectionTimeout, conn.getConnectTimeout());
+        assertNotEquals(readTimeout, conn.getReadTimeout());
     }
 
     @Test
@@ -136,7 +136,7 @@ public class ContrastSDKTest extends ContrastSDK {
     }
 
     @Test
-    public void testMalformedURL() throws IOException{
+    public void testMalformedURL() throws IOException {
         final String expectedUrl = "htp:/localhost:19080/Contrast/api";
         final String badUrl = "htp:/localhost:19080/Contrast/";
         final String actualUrl = ContrastSDKUtils.ensureApi(badUrl);
@@ -144,13 +144,13 @@ public class ContrastSDKTest extends ContrastSDK {
     }
 
     @Test
-    public void testNullUrl() throws IOException{
+    public void testNullUrl() throws IOException {
         final String nullUrl = ContrastSDKUtils.ensureApi(null);
         assertNull(nullUrl);
     }
 
     @Test
-    public void blankUrl(){
+    public void blankUrl() {
         final String blankUrl = ContrastSDKUtils.ensureApi("");
         final String ensureBlank = "";
         assertEquals(ensureBlank, blankUrl);

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -126,13 +126,33 @@ public class ContrastSDKTest extends ContrastSDK {
         final String ensureUrlOne = ContrastSDKUtils.ensureApi("http://localhost:19080/Contrast/");
         final String ensureUrlTwo = ContrastSDKUtils.ensureApi("http://localhost:19080/Contrast");
 
-        assertEquals(ensureUrlOne, expectedApi);
-        assertEquals(ensureUrlTwo, expectedApi);
+        assertEquals(expectedApi, ensureUrlOne);
+        assertEquals(expectedApi, ensureUrlTwo);
 
         final String unchangedApi = "http://localhost:19080/";
         final String ensureUnchanged = ContrastSDKUtils.ensureApi(unchangedApi);
 
         assertEquals(unchangedApi, ensureUnchanged);
     }
-    
+
+    @Test
+    public void testMalformedURL() throws IOException{
+        final String expectedUrl = "htp:/localhost:19080/Contrast/api";
+        final String badUrl = "htp:/localhost:19080/Contrast/";
+        final String actualUrl = ContrastSDKUtils.ensureApi(badUrl);
+        assertEquals(actualUrl, expectedUrl);
+    }
+
+    @Test
+    public void testNullUrl() throws IOException{
+        final String nullUrl = ContrastSDKUtils.ensureApi(null);
+        assertNull(nullUrl);
+    }
+
+    @Test
+    public void blankUrl(){
+        final String blankUrl = ContrastSDKUtils.ensureApi("");
+        final String ensureBlank = "";
+        assertEquals(ensureBlank, blankUrl);
+    }
 }

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -50,6 +50,13 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void testApplicationsNamesUrl() {
+        String expectedUrl = "/ng/test-org/applications/name";
+
+        assertEquals(expectedUrl, urlBuilder.getApplicationsNameUrl(organizationId));
+    }
+
+    @Test
     public void testCoverageUrl() {
         String expectedUrl = "/ng/test-org/applications/test-app/coverage";
 


### PR DESCRIPTION
Added the endpoint for /ng/{orgUuid}/applications/name and the request getApplicationsNames to retrieve only the names of the applications. Added to minimize the length of the response when only the name of the application is needed. 