### PR TITLE
Contrast-38919 add create app method

### DIFF
--- a/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
@@ -1,0 +1,8 @@
+package com.contrastsecurity.exceptions;
+
+public class ApplicationCreateException extends Exception {
+    public ApplicationCreateException(int rc, String message) {
+        super("Recieved Response code: "+rc+" with message: " + message);
+    }
+    private static final long serialVersionUID = -9049287248312255189L;
+}

--- a/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
@@ -1,8 +1,19 @@
 package com.contrastsecurity.exceptions;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Getter
 public class ApplicationCreateException extends Exception {
-    public ApplicationCreateException(int rc, String message) {
-        super("Recieved Response code: "+rc+" with message: " + message);
+    private final int rc;
+    private final String responseMessage;
+
+    public ApplicationCreateException(int rc, String responseMessage) {
+        super("Recieved Response code: "+rc+" with message: " + responseMessage);
+        this.rc = rc;
+        this.responseMessage = responseMessage;
     }
+
+    @Getter(AccessLevel.NONE)
     private static final long serialVersionUID = -9049287248312255189L;
 }

--- a/src/main/java/com/contrastsecurity/http/MediaType.java
+++ b/src/main/java/com/contrastsecurity/http/MediaType.java
@@ -1,0 +1,15 @@
+package com.contrastsecurity.http;
+
+public enum MediaType {
+    JSON("application/json");
+
+    private String type;
+
+    MediaType(String type) {
+        this.type = type;
+    }
+
+    public String getType(){
+        return type;
+    }
+}

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -39,6 +39,10 @@ public class UrlBuilder {
         return String.format("/ng/applications/create");
     }
 
+    public String getCreateServerUrl() {
+        return String.format("/ng/servers/");
+    }
+
     public String getApplicationsUrl(String organizationId) {
         return String.format("/ng/%s/applications?%s", organizationId, "base=false");
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -43,10 +43,6 @@ public class UrlBuilder {
         return String.format("/ng/%s/applications?%s", organizationId, "base=false");
     }
 
-    public String getApplicationsByTextFilterUrl(String organizationId, String textFilter) {
-        return String.format("/ng/%s/applications?%s&%s", organizationId, "filterText="+textFilter, "base=false");
-    }
-
     public String getApplicationsNameUrl(String organizationId) {
         return String.format("/ng/%s/applications/name", organizationId);
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -35,12 +35,8 @@ public class UrlBuilder {
         return String.format("/ng/%s/applications/%s%s", organizationId, appId, buildExpand(expandValues));
     }
 
-    public String getCreateApplicationUrl() {
-        return String.format("/ng/applications/create");
-    }
-
-    public String getCreateServerUrl() {
-        return String.format("/ng/servers/");
+    public String getCreateApplicationUrl(String organizationId) {
+        return String.format("/ng/integration/organizations/%s/applications", organizationId);
     }
 
     public String getApplicationsUrl(String organizationId) {

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -47,6 +47,10 @@ public class UrlBuilder {
         return String.format("/ng/%s/applications?%s", organizationId, "base=false");
     }
 
+    public String getApplicationsByTextFilterUrl(String organizationId, String textFilter) {
+        return String.format("/ng/%s/applications?%s&%s", organizationId, "filterText="+textFilter, "base=false");
+    }
+
     public String getApplicationsNameUrl(String organizationId) {
         return String.format("/ng/%s/applications/name", organizationId);
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -35,6 +35,10 @@ public class UrlBuilder {
         return String.format("/ng/%s/applications/%s%s", organizationId, appId, buildExpand(expandValues));
     }
 
+    public String getCreateApplicationUrl() {
+        return String.format("/ng/applications/create");
+    }
+
     public String getApplicationsUrl(String organizationId) {
         return String.format("/ng/%s/applications?%s", organizationId, "base=false");
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -36,7 +36,7 @@ public class UrlBuilder {
     }
 
     public String getCreateApplicationUrl(String organizationId) {
-        return String.format("/ng/integration/organizations/%s/applications", organizationId);
+        return String.format("/ng/integrations/organizations/%s/applications", organizationId);
     }
 
     public String getApplicationsUrl(String organizationId) {

--- a/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
+++ b/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
@@ -1,0 +1,32 @@
+package com.contrastsecurity.models.dtm;
+
+import com.contrastsecurity.models.AgentType;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ApplicationCreateRequest {
+    @SerializedName("name")
+    @NonNull
+    private String appName;
+
+    @SerializedName("language")
+    @NonNull
+    private AgentType appLanguage;
+
+    @SerializedName("appPath")
+    private String appPath;
+
+    @SerializedName("shortName")
+    private String appShortName;
+
+    public ApplicationCreateRequest(String appName, AgentType appLanguage) {
+        this.appName = appName;
+        this.appLanguage = appLanguage;
+    }
+
+
+}

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -249,7 +249,7 @@ public class ContrastSDK {
     }
 
     /**
-     * Creates a serverless application that is meant to be instrumented later.
+     * Creates an application without a server that is meant to be instrumented later.
      * @param organizationId
      * @param request
      * @return

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -50,6 +50,7 @@ import java.net.Proxy;
 import java.net.URL;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Entry point for using the Contrast REST API. Make an instance of this class
@@ -239,6 +240,10 @@ public class ContrastSDK {
             IOUtils.closeQuietly(reader);
             IOUtils.closeQuietly(is);
         }
+    }
+
+    public void createApplication(String appName) throws IOException, UnauthorizedException {
+        makeRequest(HttpMethod.PUT, this.urlBuilder.getCreateApplicationUrl());
     }
 
     /**
@@ -643,9 +648,18 @@ public class ContrastSDK {
     }
 
     public InputStream makeRequest(HttpMethod method, String path) throws IOException, UnauthorizedException {
+        return makeRequest(method, path, null);
+    }
+
+    public InputStream makeRequest(HttpMethod method, String path, Map<String, String> propertyMap) throws IOException, UnauthorizedException{
         String url = restApiURL + path;
 
         HttpURLConnection connection = makeConnection(url, method.toString());
+        if(propertyMap != null) {
+            for(Map.Entry<String, String> property: propertyMap.entrySet()) {
+                connection.setRequestProperty(property.getKey(), property.getValue());
+            }
+        }
         InputStream is = connection.getInputStream();
         int rc = connection.getResponseCode();
         if (rc >= BAD_REQUEST && rc < SERVER_ERROR) {

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -44,14 +44,8 @@ public class UrlBuilderTest {
 
     @Test
     public void testCreateApplicationUrl() {
-        String expectedUrl = "/ng/applications/create";
-        assertEquals(expectedUrl, urlBuilder.getCreateApplicationUrl());
-    }
-
-    @Test
-    public void testCreateServerUrl() {
-        String expectedUrl = "/ng/servers/";
-        assertEquals(expectedUrl, urlBuilder.getCreateServerUrl());
+        String expectedUrl = "/ng/integration/organizations/test-org/applications";
+        assertEquals(expectedUrl, urlBuilder.getCreateApplicationUrl(organizationId));
     }
 
     @Test

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -43,6 +43,18 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void testCreateApplicationUrl() {
+        String expectedUrl = "/ng/applications/create";
+        assertEquals(expectedUrl, urlBuilder.getCreateApplicationUrl());
+    }
+
+    @Test
+    public void testCreateServerUrl() {
+        String expectedUrl = "/ng/servers/";
+        assertEquals(expectedUrl, urlBuilder.getCreateServerUrl());
+    }
+
+    @Test
     public void testApplicationsUrl() {
         String expectedUrl = "/ng/test-org/applications?base=false";
 

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -44,7 +44,7 @@ public class UrlBuilderTest {
 
     @Test
     public void testCreateApplicationUrl() {
-        String expectedUrl = "/ng/integration/organizations/test-org/applications";
+        String expectedUrl = "/ng/integrations/organizations/test-org/applications";
         assertEquals(expectedUrl, urlBuilder.getCreateApplicationUrl(organizationId));
     }
 


### PR DESCRIPTION
# Problem
In the case of the contrast jenkins plugin. We need to be able to link a jenkins job to an application that has not yet been instrumented. This is to prevent the user from having to configure their jobs twice, once before the application has been instrumented and again after the application has been instrumented.

In order to link the application and the jenkins job before the application is instrumented we need to first create the application then return the application id to jenkins. The agent endpoint for creating an application poses two issues:

* It requires the application to be linked to an existing server.
* It does not return the application id.
* The response is massive

# Solution
We are creating an endpoint to be used by integrations for creating an application and return information that an integration consumes. This end point:

* Creates an application without a server

* Returns information about the application created

Once the application has been “preinstrumented” in teamserver, the agent can then fully instrument the application and the jenkins job will work without having to be reconfigured.

This change is to allow the sdk to use that endpoint.

# Summary of Changes
* Created a new method that uses the new endpoint for creating an application without a server.
    * Created a new Exception class (ApplicationCreateException) for representing errors when creating a new application
    * Created a new Enum called (MediaType) for the content-type of the request.

> Note: Depends on TeamServer


