### PR TITLE
Removing debug system.out.println that was left in by mistake.

### DIFF
--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -40,7 +40,7 @@ public class UrlBuilder {
     }
 
     public String getLicensedApplicationsUrl(String organizationId) {
-        return String.format("/ng/%s/applications%s", organizationId, "/filter?sort=appName&quickFilter=LICENSED");
+        return String.format("/ng/%s/applications%s", organizationId, "/filter?expand=license&sort=appName&quickFilter=LICENSED");
     }
 
     public String getApplicationsNameUrl(String organizationId) {


### PR DESCRIPTION
Not sure why it's showing line 43 as changed, that expand=license was already in the main repo.  The change was actually to remove a System.out.println() in ContrastSDK.getLicensedApplications() function.  That system.out.println() is not actually in the main repo anyway.  This might be an unneeded push request but I wanted to fix up my fork.