### PR TITLE
CONTRAST-38919-add-get-app-by-name-and-language

### DIFF
--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -39,6 +39,10 @@ public class UrlBuilder {
         return String.format("/ng/integrations/organizations/%s/applications", organizationId);
     }
 
+    public String getApplicationByNameAndLanguageUrl(String organizationId, String appName, String language) {
+        return String.format("/ng/integrations/organizations/%s/applications?name=%s&language=%s", organizationId, appName, language);
+    }
+
     public String getApplicationsUrl(String organizationId) {
         return String.format("/ng/%s/applications?%s", organizationId, "base=false");
     }

--- a/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
+++ b/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
@@ -17,7 +17,7 @@ public class ApplicationCreateRequest {
     @NonNull
     private AgentType appLanguage;
 
-    @SerializedName("appPath")
+    @SerializedName("path")
     private String appPath;
 
     @SerializedName("shortName")

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -266,6 +266,23 @@ public class ContrastSDK {
     }
 
     /**
+     * Gets a single application based on the org, name, and language
+     * @param orgId ID of the organization
+     * @param appName Application name when the application was first created
+     * @param language Language of the application
+     * @return
+     * @throws IOException
+     * @throws UnauthorizedException
+     */
+    public Application getApplicationByNameAndLanguage(String orgId, String appName, AgentType language) throws IOException, UnauthorizedException{
+        try (InputStream is = makeRequest(HttpMethod.GET, urlBuilder.getApplicationByNameAndLanguageUrl(orgId, appName, language.name()));
+             InputStreamReader reader = new InputStreamReader(is)) {
+            Applications response = this.gson.fromJson(reader, Applications.class);
+            return response.getApplication();
+        }
+    }
+
+    /**
      * Private helper method for createApplication to make a request with special error handling
      * @param method
      * @param path

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -270,7 +270,7 @@ public class ContrastSDK {
      * @param orgId ID of the organization
      * @param appName Application name when the application was first created
      * @param language Language of the application
-     * @return
+     * @return the Application found, returns null if the application is not found
      * @throws IOException
      * @throws UnauthorizedException
      */

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -49,6 +49,12 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void testApplicationByNameAndLanguageUrl() {
+        String expectedUrl = "/ng/integrations/organizations/test-org/applications?name=app&language=JAVA";
+        assertEquals(expectedUrl, urlBuilder.getApplicationByNameAndLanguageUrl(organizationId, "app", "JAVA"));
+    }
+
+    @Test
     public void testApplicationsUrl() {
         String expectedUrl = "/ng/test-org/applications?base=false";
 


### PR DESCRIPTION
# Problem
Unable to get an already existing application without the APP ID

# Solution
Create a method that accepts an application's name, language, and org to find a matching application

# Summary of Changes
Added a method to get an application based on name, language, and org