### PR TITLE
Contrast 38919 add agent types

### DIFF
--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -139,9 +139,6 @@ public class UrlBuilder {
             case DOTNET_CORE:
                 url = String.format("/ng/%s/agents/%s/dotnet_core", organizationId, profileName);
                 break;
-            case PROXY:
-                url = String.format("/ng/%s/agents/external/%s/proxy", organizationId, profileName);
-                break;
             default:
                 url = "";
                 break;

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -140,7 +140,7 @@ public class UrlBuilder {
                 url = String.format("/ng/%s/agents/%s/dotnet_core", organizationId, profileName);
                 break;
             case PROXY:
-                url = String.format("/ng/%s/agents/%s/proxy", organizationId, profileName);
+                url = String.format("/ng/%s/agents/external/%s/proxy", organizationId, profileName);
                 break;
             default:
                 url = "";

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -117,16 +117,34 @@ public class UrlBuilder {
     public String getAgentUrl(AgentType type, String organizationId, String profileName) {
         String url;
 
-        if (AgentType.JAVA.equals(type)) {
-            url = String.format("/ng/%s/agents/%s/java?jvm=1_6", organizationId, profileName);
-        } else if (AgentType.JAVA1_5.equals(type)) {
-            url = String.format("/ng/%s/agents/%s/java?jvm=1_5", organizationId, profileName);
-        } else if (AgentType.DOTNET.equals(type)) {
-            url = String.format("/ng/%s/agents/%s/dotnet", organizationId, profileName);
-        } else if (AgentType.NODE.equals(type)) {
-            url = String.format("/ng/%s/agents/%s/node", organizationId, profileName);
-        } else {
-            url = "";
+        switch(type) {
+            case JAVA:
+                url = String.format("/ng/%s/agents/%s/java?jvm=1_6", organizationId, profileName);
+                break;
+            case JAVA1_5:
+                url = String.format("/ng/%s/agents/%s/java?jvm=1_5", organizationId, profileName);
+                break;
+            case DOTNET:
+                url = String.format("/ng/%s/agents/%s/dotnet", organizationId, profileName);
+                break;
+            case NODE:
+                url = String.format("/ng/%s/agents/%s/node", organizationId, profileName);
+                break;
+            case RUBY:
+                url = String.format("/ng/%s/agents/%s/ruby", organizationId, profileName);
+                break;
+            case PYTHON:
+                url = String.format("/ng/%s/agents/%s/python", organizationId, profileName);
+                break;
+            case DOTNET_CORE:
+                url = String.format("/ng/%s/agents/%s/dotnet_core", organizationId, profileName);
+                break;
+            case PROXY:
+                url = String.format("/ng/%s/agents/%s/proxy", organizationId, profileName);
+                break;
+            default:
+                url = "";
+                break;
         }
 
         return url;

--- a/src/main/java/com/contrastsecurity/models/AgentType.java
+++ b/src/main/java/com/contrastsecurity/models/AgentType.java
@@ -7,5 +7,9 @@ public enum AgentType {
 	JAVA,
 	JAVA1_5,
 	DOTNET,
-	NODE
+	NODE,
+	RUBY,
+	PROXY,
+	PYTHON,
+	DOTNET_CORE
 }

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -129,6 +129,22 @@ public class UrlBuilderTest {
         String expectedDotNetProfile = "/ng/test-org/agents/default/dotnet";
 
         assertEquals(expectedDotNetProfile, urlBuilder.getAgentUrl(AgentType.DOTNET, organizationId, "default"));
+
+        String expectedRubyUrl = "/ng/test-org/agents/default/ruby";
+
+        assertEquals(expectedRubyUrl, urlBuilder.getAgentUrl(AgentType.RUBY, organizationId, "default"));
+
+        String expectedPythonUrl = "/ng/test-org/agents/default/python";
+
+        assertEquals(expectedPythonUrl, urlBuilder.getAgentUrl(AgentType.PYTHON, organizationId, "default"));
+
+        String expectedDotNetCoreUrl = "/ng/test-org/agents/default/dotnet_core";
+
+        assertEquals(expectedDotNetCoreUrl, urlBuilder.getAgentUrl(AgentType.DOTNET_CORE, organizationId, "default"));
+
+        String expectedProxyUrl = "/ng/test-org/agents/default/proxy";
+
+        assertEquals(expectedProxyUrl, urlBuilder.getAgentUrl(AgentType.PROXY, organizationId, "default"));
     }
 
 }

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -141,10 +141,6 @@ public class UrlBuilderTest {
         String expectedDotNetCoreUrl = "/ng/test-org/agents/default/dotnet_core";
 
         assertEquals(expectedDotNetCoreUrl, urlBuilder.getAgentUrl(AgentType.DOTNET_CORE, organizationId, "default"));
-
-        String expectedProxyUrl = "/ng/test-org/agents/external/default/proxy";
-
-        assertEquals(expectedProxyUrl, urlBuilder.getAgentUrl(AgentType.PROXY, organizationId, "default"));
     }
 
 }

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -142,7 +142,7 @@ public class UrlBuilderTest {
 
         assertEquals(expectedDotNetCoreUrl, urlBuilder.getAgentUrl(AgentType.DOTNET_CORE, organizationId, "default"));
 
-        String expectedProxyUrl = "/ng/test-org/agents/default/proxy";
+        String expectedProxyUrl = "/ng/test-org/agents/external/default/proxy";
 
         assertEquals(expectedProxyUrl, urlBuilder.getAgentUrl(AgentType.PROXY, organizationId, "default"));
     }


### PR DESCRIPTION
CONTRAST-38919

# Problem
Sdk's AgentType enum is missing some agents. So the user cannot specify a language they see in contrast but sdk does not support.

# Solution
Add missing AgentTypes.

# Summmary of changes.
1. Added missing agent types to AgentType enum
1. add agentUrl