### PR TITLE
Contrast 39403 update sdk for new security check

### DIFF
--- a/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -54,7 +54,7 @@ public class SecurityCheckForm {
      * @returnThe origin of the security check
      */
     @SerializedName("origin")
-    private SecurityCheck.Origin origin = SecurityCheck.Origin.OTHER;
+    private String origin = "OTHER";
 
     /**
      * Filter the application's vulnerabilities using start date in milliseconds.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -1,42 +1,67 @@
 package com.contrastsecurity.http;
 
+import com.contrastsecurity.models.AgentType;
 import com.contrastsecurity.models.SecurityCheck;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
+import java.util.List;
+
+/**
+ * Form that is used making security checks
+ */
+@Getter
+@Setter
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class SecurityCheckForm {
+
+    /**
+     * The name of the application to be verified
+     * @param applicationName New value for application name.
+     * @return The name of the application.
+     */
+    @SerializedName("application_name")
+    @NonNull
     private String applicationName;
-    private String appVersion;
-    private long timestamp;
-    private SecurityCheck.Origin origin;
 
-    public String getApplicationName() {
-        return applicationName;
-    }
+    /**
+     * The language of the agent used to instrument the application
+     * @param agentLanguage New value for agent language.
+     * @return the agent language of the application
+     */
+    @SerializedName("agent_language")
+    @NonNull
+    private AgentType agentLanguage;
 
-    public void setApplicationName(String applicationName) {
-        this.applicationName = applicationName;
-    }
+    /**
+     * Filter the application's vulnerabilities using app version tags.
+     * Do not set if you want to verify against all of the application's vulnerabilities.
+     * @param appVersionTags New appVersionTags.
+     * @return The appVersionTags filter
+     */
+    @SerializedName("app_version_tags")
+    private List<String> appVersionTags;
 
-    public String getAppVersion() {
-        return appVersion;
-    }
+    /**
+     * Where the request is being made
+     * Default: OTHER
+     * @param origin New origin for the security check
+     * @returnThe origin of the security check
+     */
+    @SerializedName("origin")
+    private SecurityCheck.Origin origin = SecurityCheck.Origin.OTHER;
 
-    public void setAppVersion(String appVersion) {
-        this.appVersion = appVersion;
-    }
-
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public SecurityCheck.Origin getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(SecurityCheck.Origin origin) {
-        this.origin = origin;
-    }
+    /**
+     * Filter the application's vulnerabilities using start date in milliseconds.
+     * Do not set if you want to verify against all of the application's vulnerabilities.
+     * @param startDate New start date.
+     * @return The start date filter
+     */
+    @SerializedName("start_date")
+    private Long startDate;
 }

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
@@ -1,0 +1,19 @@
+package com.contrastsecurity.http;
+
+import com.contrastsecurity.models.SecurityCheck;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+/**
+ * A wrapper object for the response of a security check request
+ */
+@Getter
+public class SecurityCheckResponse {
+  /**
+   * The resulting security check
+   * @return the security check
+   */
+  @SerializedName("security_check")
+  private SecurityCheck securityCheck;
+
+}

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -108,7 +108,7 @@ public class UrlBuilder {
         return String.format("/ng/%s/rules", organizationId);
     }
 
-    public String postSecurityCheck(String organizationId) {
+    public String getSecurityCheckUrl(String organizationId) {
         return String.format("/ng/%s/securityChecks", organizationId);
     }
 

--- a/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
+++ b/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
@@ -1,108 +1,76 @@
 package com.contrastsecurity.models;
 
+import com.contrastsecurity.http.RuleSeverity;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
 import java.util.List;
+import java.util.Map;
 
+/**
+ * A security policy used for verifying an application
+ */
+@Getter
 public class JobOutcomePolicy {
-
-    public enum Direction {
-        INCLUDE,
-        EXCLUDE
-    }
-
     public enum Outcome {
         SUCCESS,
         FAIL,
         UNSTABLE
     }
 
+    /**
+     * The ID of the job outcome policy.
+     * @return The ID of the job outcome policy.
+     */
+    @SerializedName("policy_id")
     private long id;
-    private String applicationName;
-    private List<ApplicationImportance> importances;
-    private boolean allApplications;
-    private List<String> rules;
-    private Direction direction;
-    private String status; //Potential to turn this into an enum
-    private List<JobOutcomePolicySeverity> vulnerabilitySeverities;
+
+    /**
+     * The name of the job outcome policy.
+     * @return The name of the job outcome policy.
+     */
+    @SerializedName("name")
+    private String name;
+
+    /**
+     * Whether the threshold was set of all rules.
+     * @return whether the threshold was set for all rules.
+     */
+    @SerializedName("all_rules")
+    private boolean allRules;
+
+    /**
+     * The threshold for all rules.
+     * @return The threshold for all rules.
+     */
+    @SerializedName("all_rules_threshold")
+    private long allRulesThreshold;
+
+    /**
+     * List of specific rules and their thresholds.
+     * @return List of rules and their thresholds.
+     */
+    @SerializedName("rules")
+    private Map<String, Long> rules;
+
+    /**
+     * List of vulnerability statuses that were considered.
+     * @return List of vulnerability statuses that were considered.
+     */
+    @SerializedName("status_filter")
+    private List<String> statusFilter;
+
+    /**
+     * List of severities and their thresholds.
+     * @return List of severities and their thresholds.
+     */
+    @SerializedName("severities")
+    private Map<RuleSeverity, Long> severities;
+
+    /**
+     * Result of the job if the application fails the job outcome policy.
+     * @return result of the job if the application fails the job outcome policy.
+     */
+    @SerializedName("outcome")
     private Outcome outcome;
-    private boolean enabled;
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public String getApplicationName() {
-        return applicationName;
-    }
-
-    public void setApplicationName(String applicationName) {
-        this.applicationName = applicationName;
-    }
-
-    public List<ApplicationImportance> getImportances() {
-        return importances;
-    }
-
-    public void setImportances(List<ApplicationImportance> importances) {
-        this.importances = importances;
-    }
-
-    public boolean isAllApplications() {
-        return allApplications;
-    }
-
-    public void setAllApplications(boolean allApplications) {
-        this.allApplications = allApplications;
-    }
-
-    public List<String> getRules() {
-        return rules;
-    }
-
-    public void setRules(List<String> rules) {
-        this.rules = rules;
-    }
-
-    public Direction getDirection() {
-        return direction;
-    }
-
-    public void setDirection(Direction direction) {
-        this.direction = direction;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
-    }
-
-    public List<JobOutcomePolicySeverity> getVulnerabilitySeverities() {
-        return vulnerabilitySeverities;
-    }
-
-    public void setVulnerabilitySeverities(List<JobOutcomePolicySeverity> vulnerabilitySeverities) {
-        this.vulnerabilitySeverities = vulnerabilitySeverities;
-    }
-
-    public Outcome getOutcome() {
-        return outcome;
-    }
-
-    public void setOutcome(Outcome outcome) {
-        this.outcome = outcome;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
 }

--- a/src/main/java/com/contrastsecurity/models/SecurityCheck.java
+++ b/src/main/java/com/contrastsecurity/models/SecurityCheck.java
@@ -1,64 +1,58 @@
 package com.contrastsecurity.models;
 
-public class SecurityCheck {
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
 
+@Getter
+public class SecurityCheck {
     public enum Origin {
         OTHER,
         JENKINS
     }
 
-    private long id;
+    /**
+     * The ID of the security check
+     * @return the ID of the security check.
+     */
+    @SerializedName("id")
+    private Long id;
+
+    /**
+     * The name of the application verified.
+     * @return the name of the application
+     */
+    @SerializedName("application_name")
     private String applicationName;
+
+    /**
+     * The ID of the application verified.
+     * @return the ID of the application.
+     */
+    @SerializedName("application_id")
     private String applicationId;
+
+    /**
+     * The origin of where the security check was made from.
+     * @return the origin of the security check.
+     */
+    @SerializedName("origin")
     private Origin origin;
-    private String result;
+
+    /**
+     * The result of the security check
+     * true = the application passed all job outcome policies.
+     * false = the application failed a job outcome policy.
+     * @return the result of the security check.
+     */
+    @SerializedName("result")
+    private boolean pass;
+
+
+    /**
+     * The job outcome policy that the application failed.
+     * null if the application passed all job outcome policies.
+     * @reutnr The job outcome policy that the application failed.
+     */
+    @SerializedName("job_outcome_policy")
     private JobOutcomePolicy jobOutcomePolicy;
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public String getApplicationName() {
-        return applicationName;
-    }
-
-    public void setApplicationName(String applicationName) {
-        this.applicationName = applicationName;
-    }
-
-    public String getApplicationId() {
-        return applicationId;
-    }
-
-    public void setApplicationId(String applicationId) {
-        this.applicationId = applicationId;
-    }
-
-    public Origin getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(Origin origin) {
-        this.origin = origin;
-    }
-
-    public String getResult() {
-        return result;
-    }
-
-    public void setResult(String result) {
-        this.result = result;
-    }
-
-    public JobOutcomePolicy getJobOutcomePolicy() {
-        return jobOutcomePolicy;
-    }
-
-    public void setJobOutcomePolicy(JobOutcomePolicy jobOutcomePolicy) {
-        this.jobOutcomePolicy = jobOutcomePolicy;
-    }
 }

--- a/src/main/java/com/contrastsecurity/models/SecurityCheck.java
+++ b/src/main/java/com/contrastsecurity/models/SecurityCheck.java
@@ -5,10 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class SecurityCheck {
-    public enum Origin {
-        OTHER,
-        JENKINS
-    }
 
     /**
      * The ID of the security check
@@ -36,7 +32,7 @@ public class SecurityCheck {
      * @return the origin of the security check.
      */
     @SerializedName("origin")
-    private Origin origin;
+    private String origin;
 
     /**
      * The result of the security check

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -714,7 +714,7 @@ public class ContrastSDK {
         InputStream is = null;
         InputStreamReader reader = null;
         try {
-            is = makeRequestWithBody(HttpMethod.POST, urlBuilder.postSecurityCheck(organizationId), this.gson.toJson(securityCheckForm), MediaType.JSON);
+            is = makeRequestWithBody(HttpMethod.POST, urlBuilder.getSecurityCheckUrl(organizationId), this.gson.toJson(securityCheckForm), MediaType.JSON);
             reader = new InputStreamReader(is);
 
             SecurityCheckResponse response = this.gson.fromJson(reader, SecurityCheckResponse.class);

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -34,6 +34,8 @@ import com.contrastsecurity.http.FilterForm;
 import com.contrastsecurity.http.HttpMethod;
 import com.contrastsecurity.http.MediaType;
 import com.contrastsecurity.http.RequestConstants;
+import com.contrastsecurity.http.SecurityCheckForm;
+import com.contrastsecurity.http.SecurityCheckResponse;
 import com.contrastsecurity.http.ServerFilterForm;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.http.TraceFilterKeycode;
@@ -699,15 +701,24 @@ public class ContrastSDK {
         }
     }
 
-    public SecurityCheck securityCheck(String organizationId, String applicationName, String applicationVersion, Long timestamp) throws IOException, UnauthorizedException {
+    /**
+     * Make a security check in a given organization by the security check form
+     *
+     * @param organizationId the ID of the organization
+     * @param securityCheckForm the security check form
+     * @return the security check that was made
+     * @throws IOException
+     * @throws UnauthorizedException
+     */
+    public SecurityCheck makeSecurityCheck(String organizationId, SecurityCheckForm securityCheckForm) throws IOException, UnauthorizedException {
         InputStream is = null;
         InputStreamReader reader = null;
-
         try {
-            is = makeRequest(HttpMethod.POST, urlBuilder.postSecurityCheck(organizationId));
+            is = makeRequestWithBody(HttpMethod.POST, urlBuilder.postSecurityCheck(organizationId), this.gson.toJson(securityCheckForm), MediaType.JSON);
             reader = new InputStreamReader(is);
 
-            return this.gson.fromJson(reader, SecurityCheck.class);
+            SecurityCheckResponse response = this.gson.fromJson(reader, SecurityCheckResponse.class);
+            return response.getSecurityCheck();
         } finally {
             IOUtils.closeQuietly(is);
             IOUtils.closeQuietly(reader);
@@ -775,6 +786,29 @@ public class ContrastSDK {
      */
     public byte[] getAgent(AgentType type, String organizationId) throws IOException, UnauthorizedException {
         return getAgent(type, organizationId, DEFAULT_AGENT_PROFILE);
+    }
+
+    public InputStream makeRequestWithBody(HttpMethod method, String path, String body, MediaType mediaType) throws IOException, UnauthorizedException {
+        String url = restApiURL + path;
+        OutputStream os = null;
+        HttpURLConnection connection = makeConnection(url, method.toString());
+        if(mediaType != null && body != null && (method.equals(HttpMethod.PUT) || method.equals(HttpMethod.POST))) {
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-Type",mediaType.getType());
+            os = connection.getOutputStream();
+            byte[] bodyByte = body.getBytes("utf-8");
+            os.write(bodyByte, 0, bodyByte.length);
+        }
+        int rc = connection.getResponseCode();
+        InputStream is = connection.getInputStream();
+        if (rc >= BAD_REQUEST && rc < SERVER_ERROR) {
+            IOUtils.closeQuietly(is);
+            if(os != null) {
+                IOUtils.closeQuietly(os);
+            }
+            throw new UnauthorizedException(rc);
+        }
+        return is;
     }
 
     public InputStream makeRequest(HttpMethod method, String path) throws IOException, UnauthorizedException {

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -4,6 +4,8 @@ import com.contrastsecurity.exceptions.InvalidConversionException;
 import com.contrastsecurity.exceptions.ResourceNotFoundException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.HttpMethod;
+import com.contrastsecurity.http.RuleSeverity;
+import com.contrastsecurity.http.SecurityCheckResponse;
 import com.contrastsecurity.models.*;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.contrastsecurity.utils.ContrastSDKUtils;
@@ -120,6 +122,22 @@ public class ContrastSDKTest extends ContrastSDK {
 
         assertNotNull(servers);
         assertNotNull(servers.getServers());
+    }
+
+    @Test
+    public void testMakeSecurityCheck() {
+        String securityCheckResponseString = "{'security_check':{'id':1,'application_name':'testName','application_id':'testId1','origin':'JENKINS','result':false, 'job_outcome_policy':{'name':'testPolicy','outcome':'UNSTABLE','severities':{'MEDIUM':1}}}}";
+
+        SecurityCheckResponse response = gson.fromJson(securityCheckResponseString, SecurityCheckResponse.class);
+        SecurityCheck securityCheck = response.getSecurityCheck();
+        JobOutcomePolicy jobOutcomePolicy = securityCheck.getJobOutcomePolicy();
+        assertEquals(1l, securityCheck.getId().longValue());
+        assertEquals("testName", securityCheck.getApplicationName());
+        assertEquals("testPolicy", jobOutcomePolicy.getName());
+        assertEquals(JobOutcomePolicy.Outcome.UNSTABLE, jobOutcomePolicy.getOutcome());
+        assertEquals(1, jobOutcomePolicy.getSeverities().size());
+        assertEquals(1l, jobOutcomePolicy.getSeverities().get(RuleSeverity.MEDIUM).longValue());
+
     }
 
     @Test

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -117,6 +117,12 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void testSecurityCheckUrl() {
+        String expectedSecurityCheckUrl = "/ng/test-org/securityChecks";
+        assertEquals(expectedSecurityCheckUrl, urlBuilder.getSecurityCheckUrl(organizationId));
+    }
+
+    @Test
     public void testAgentUrls() {
         String expectedJavaUrl = "/ng/test-org/agents/default/java?jvm=1_6";
 


### PR DESCRIPTION
# Depends on
https://bitbucket.org/contrastsecurity/teamserver/pull-requests/9772/contrast-39403-calculate-security-check/diff

# Problem
New changes were made in the server api

# Solution
Update the sdk to be able to make a security check

# Summary of changes
* Added a new makeRequestWithBody to ContrastSDK to be able to make a request with a body
* Added SecurityCheckResponse as a wrapper to handle the security check response
* Updated JobOutcomePolicy fields.
* Updated SecurityCheck fields.
* Updated makeSecurityCheck method.

# Steps to verify
1. make a security check for an application that is supposed to pass.
1. verify that security check fields are populated properly.
1. verify that the security check result is true and job outcome policy is null.
1. make a security check for an application that is supposed to fail.
1. verify that the security check result is false and job outcome policy contains the job outcome policy that the application failed.
1. verify that the job outcome policy fields are populated properly.



