### PR TITLE
Contrast security check result

### DIFF
--- a/src/main/java/com/contrastsecurity/models/SecurityCheck.java
+++ b/src/main/java/com/contrastsecurity/models/SecurityCheck.java
@@ -38,10 +38,11 @@ public class SecurityCheck {
      * The result of the security check
      * true = the application passed all job outcome policies.
      * false = the application failed a job outcome policy.
+     * null = no applicable job outcome policy for application.
      * @return the result of the security check.
      */
     @SerializedName("result")
-    private boolean pass;
+    private Boolean result;
 
 
     /**


### PR DESCRIPTION
# Problem
Need to know if no policy is defined for application

# Summary of changes
* Made result nullable, meaning security check was not run because no policy is defined for the application.