### PR TITLE
Add application id to security check to allow identifying the application

### DIFF
--- a/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -16,9 +16,16 @@ import java.util.List;
  */
 @Getter
 @Setter
-@RequiredArgsConstructor
 @AllArgsConstructor
 public class SecurityCheckForm {
+
+    /**
+     * The ID of the application to be verified
+     * @param applicationId New value for application id.
+     * @return The ID of the application
+     */
+    @SerializedName("application_id")
+    private String applicationId;
 
     /**
      * The name of the application to be verified
@@ -26,7 +33,6 @@ public class SecurityCheckForm {
      * @return The name of the application.
      */
     @SerializedName("application_name")
-    @NonNull
     private String applicationName;
 
     /**
@@ -35,7 +41,6 @@ public class SecurityCheckForm {
      * @return the agent language of the application
      */
     @SerializedName("agent_language")
-    @NonNull
     private AgentType agentLanguage;
 
     /**
@@ -64,4 +69,13 @@ public class SecurityCheckForm {
      */
     @SerializedName("start_date")
     private Long startDate;
+
+    public SecurityCheckForm(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public SecurityCheckForm(String applicationName, AgentType agentLanguage) {
+        this.applicationName = applicationName;
+        this.agentLanguage = agentLanguage;
+    }
 }


### PR DESCRIPTION
# Depends on
https://bitbucket.org/contrastsecurity/teamserver/pull-requests/9871/contrast-39402-add-support-for-app-id-in

# Purpose
Add application id to security check form to allow identifying application using application id.

# Context
Sometimes a user may only have the application id with no reliable way to get the application's original name and language. To solve this, we are adding the ability for the user to identify the application they would like to perform a security check against using the application's id.

# Summary of Changes
* Added applicationId to SecurityCheckForm
* Created two constructors for SecurityCheckForm
    * One for applicationId
    * Another for applicationName and agentLanguage
    * This only allows an instance of SecurityCheckForm to be created with either the applicationId, or the applicationName and agentLanguage provided.