### PR TITLE
Contrast 39516 add get enabled policies

### DIFF
--- a/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
+++ b/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
@@ -1,0 +1,21 @@
+package com.contrastsecurity.http;
+
+import com.contrastsecurity.models.JobOutcomePolicy;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Wrapper for the response object returned by Contrast
+ */
+@Getter
+public class JobOutcomePolicyListResponse {
+
+  /**
+   * List of job outcome policies
+   * @return The list of job outcome policies
+   */
+  @SerializedName("policies")
+  private List<JobOutcomePolicy> policies;
+}

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -113,11 +113,11 @@ public class UrlBuilder {
     }
 
     public String getEnabledJobOutcomePolicyListUrl(String organizationId) {
-        return String.format("/ng/%s/jobOutcomePolicies/enabled/no-fill-app", organizationId);
+        return String.format("/ng/%s/jobOutcomePolicies/enabled", organizationId);
     }
 
     public String getEnabledJobOutcomePolicyListUrlByApplication(String organizationId, String appId) {
-      return String.format("/ng/%s/jobOutcomePolicies/enabled/no-fill-app/%s", organizationId, appId);
+      return String.format("/ng/%s/jobOutcomePolicies/enabled/%s", organizationId, appId);
     }
 
     public String getAssessLicensingUrl(String organizationId) {

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -112,6 +112,10 @@ public class UrlBuilder {
         return String.format("/ng/%s/securityChecks", organizationId);
     }
 
+    public String getEnabledJobOutcomePolicyListUrl(String organizationId) {
+        return String.format("/ng/%s/jobOutcomePolicies/enabled/noFillApp", organizationId);
+    }
+
     public String getAssessLicensingUrl(String organizationId) {
         return String.format("/ng/%s/licenses", organizationId);
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -116,6 +116,10 @@ public class UrlBuilder {
         return String.format("/ng/%s/jobOutcomePolicies/enabled/noFillApp", organizationId);
     }
 
+    public String getEnabledJobOutcomePolicyListUrlByApplication(String organizationId, String appId) {
+      return String.format("/ng/%s/jobOutcomePolicies/enabled/noFillApp/%s", organizationId, appId);
+    }
+
     public String getAssessLicensingUrl(String organizationId) {
         return String.format("/ng/%s/licenses", organizationId);
     }

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -113,11 +113,11 @@ public class UrlBuilder {
     }
 
     public String getEnabledJobOutcomePolicyListUrl(String organizationId) {
-        return String.format("/ng/%s/jobOutcomePolicies/enabled/noFillApp", organizationId);
+        return String.format("/ng/%s/jobOutcomePolicies/enabled/no-fill-app", organizationId);
     }
 
     public String getEnabledJobOutcomePolicyListUrlByApplication(String organizationId, String appId) {
-      return String.format("/ng/%s/jobOutcomePolicies/enabled/noFillApp/%s", organizationId, appId);
+      return String.format("/ng/%s/jobOutcomePolicies/enabled/no-fill-app/%s", organizationId, appId);
     }
 
     public String getAssessLicensingUrl(String organizationId) {

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -727,8 +727,8 @@ public class ContrastSDK {
     }
 
     /**
-     * Gets a list of enabled Job Outcome policies for an organization
-     * @param organizationId The organization
+     * Gets a list of enabled Job Outcome policies in an organization
+     * @param organizationId The organization ID
      * @return The list of enabled Job Outcome Policies
      * @throws IOException
      * @throws UnauthorizedException
@@ -738,6 +738,27 @@ public class ContrastSDK {
         InputStreamReader reader = null;
         try {
             is = makeRequest(HttpMethod.GET, urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
+            reader = new InputStreamReader(is);
+
+            JobOutcomePolicyListResponse response = this.gson.fromJson(reader, JobOutcomePolicyListResponse.class);
+            return response.getPolicies();
+        } finally {
+            IOUtils.closeQuietly(is);
+            IOUtils.closeQuietly(reader);
+        }
+    }
+
+    /**
+     * Gets a list of enabeld Job Outcome Policies in an organization that applies to an application
+     * @param organizationId The organization ID
+     * @param appId The Application ID
+     * @return the list of enabled Job Outcome Policies that apply to the application
+     */
+    public List<JobOutcomePolicy> getEnabledJoboutcomePoliciesByApplication(String organizationId, String appId) throws IOException, UnauthorizedException {
+        InputStream is = null;
+        InputStreamReader reader = null;
+        try {
+            is = makeRequest(HttpMethod.GET, urlBuilder.getEnabledJobOutcomePolicyListUrlByApplication(organizationId, appId));
             reader = new InputStreamReader(is);
 
             JobOutcomePolicyListResponse response = this.gson.fromJson(reader, JobOutcomePolicyListResponse.class);

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -32,6 +32,7 @@ import com.contrastsecurity.exceptions.ApplicationCreateException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.FilterForm;
 import com.contrastsecurity.http.HttpMethod;
+import com.contrastsecurity.http.JobOutcomePolicyListResponse;
 import com.contrastsecurity.http.MediaType;
 import com.contrastsecurity.http.RequestConstants;
 import com.contrastsecurity.http.SecurityCheckForm;
@@ -719,6 +720,28 @@ public class ContrastSDK {
 
             SecurityCheckResponse response = this.gson.fromJson(reader, SecurityCheckResponse.class);
             return response.getSecurityCheck();
+        } finally {
+            IOUtils.closeQuietly(is);
+            IOUtils.closeQuietly(reader);
+        }
+    }
+
+    /**
+     * Gets a list of enabled Job Outcome policies for an organization
+     * @param organizationId The organization
+     * @return The list of enabled Job Outcome Policies
+     * @throws IOException
+     * @throws UnauthorizedException
+     */
+    public List<JobOutcomePolicy> getEnabledJobOutcomePolicies(String organizationId) throws IOException, UnauthorizedException {
+        InputStream is = null;
+        InputStreamReader reader = null;
+        try {
+            is = makeRequest(HttpMethod.GET, urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
+            reader = new InputStreamReader(is);
+
+            JobOutcomePolicyListResponse response = this.gson.fromJson(reader, JobOutcomePolicyListResponse.class);
+            return response.getPolicies();
         } finally {
             IOUtils.closeQuietly(is);
             IOUtils.closeQuietly(reader);

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -142,8 +142,16 @@ public class ContrastSDKTest extends ContrastSDK {
     }
 
     @Test
-    public void testGetJobOutcomePolicies() {
+    public void testGetEnabledJobOutcomePolicies() {
         String jobOutcomePolicyListResponseString = "{'policies':[{'name':'testJobOutcomePolicy','outcome':'SUCCESS'}]}";
+        JobOutcomePolicyListResponse response = gson.fromJson(jobOutcomePolicyListResponseString, JobOutcomePolicyListResponse.class);
+        assertNotNull(response.getPolicies());
+        assertEquals(response.getPolicies().get(0).getName(), "testJobOutcomePolicy");
+    }
+
+    @Test
+    public void testGetEnabledJobOutcomePoliciesByApplication() {
+        String jobOutcomePolicyListResponseString = "{'policies':[{'name':'testJobOutcomePolicy','outcome':'UNSTABLE'}]}";
         JobOutcomePolicyListResponse response = gson.fromJson(jobOutcomePolicyListResponseString, JobOutcomePolicyListResponse.class);
         assertNotNull(response.getPolicies());
         assertEquals(response.getPolicies().get(0).getName(), "testJobOutcomePolicy");

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -4,6 +4,7 @@ import com.contrastsecurity.exceptions.InvalidConversionException;
 import com.contrastsecurity.exceptions.ResourceNotFoundException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.HttpMethod;
+import com.contrastsecurity.http.JobOutcomePolicyListResponse;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.SecurityCheckResponse;
 import com.contrastsecurity.models.*;
@@ -138,6 +139,14 @@ public class ContrastSDKTest extends ContrastSDK {
         assertEquals(1, jobOutcomePolicy.getSeverities().size());
         assertEquals(1l, jobOutcomePolicy.getSeverities().get(RuleSeverity.MEDIUM).longValue());
 
+    }
+
+    @Test
+    public void testGetJobOutcomePolicies() {
+        String jobOutcomePolicyListResponseString = "{'policies':[{'name':'testJobOutcomePolicy','outcome':'SUCCESS'}]}";
+        JobOutcomePolicyListResponse response = gson.fromJson(jobOutcomePolicyListResponseString, JobOutcomePolicyListResponse.class);
+        assertNotNull(response.getPolicies());
+        assertEquals(response.getPolicies().get(0).getName(), "testJobOutcomePolicy");
     }
 
     @Test

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -123,6 +123,12 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void testJobOutcomePolicyListUrl() {
+        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/noFillApp";
+        assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
+    }
+
+    @Test
     public void testAgentUrls() {
         String expectedJavaUrl = "/ng/test-org/agents/default/java?jvm=1_6";
 

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -124,13 +124,13 @@ public class UrlBuilderTest {
 
     @Test
     public void testEnabledJobOutcomePolicyListUrl() {
-        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/no-fill-app";
+        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled";
         assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
     }
 
     @Test
     public void testEnabledJobOutcomePolicyListUrlByApplication() {
-        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/no-fill-app/test-app";
+        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/test-app";
         assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrlByApplication(organizationId, applicationId));
     }
 

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -123,9 +123,15 @@ public class UrlBuilderTest {
     }
 
     @Test
-    public void testJobOutcomePolicyListUrl() {
+    public void testEnabledJobOutcomePolicyListUrl() {
         String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/noFillApp";
         assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
+    }
+
+    @Test
+    public void testEnabledJobOutcomePolicyListUrlByApplication() {
+        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/noFillApp/test-app";
+        assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrlByApplication(organizationId, applicationId));
     }
 
     @Test

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -124,13 +124,13 @@ public class UrlBuilderTest {
 
     @Test
     public void testEnabledJobOutcomePolicyListUrl() {
-        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/noFillApp";
+        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/no-fill-app";
         assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
     }
 
     @Test
     public void testEnabledJobOutcomePolicyListUrlByApplication() {
-        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/noFillApp/test-app";
+        String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/no-fill-app/test-app";
         assertEquals(expectedJobOutcomePolicyListUrl, urlBuilder.getEnabledJobOutcomePolicyListUrlByApplication(organizationId, applicationId));
     }
 


### PR DESCRIPTION
# Dependency
https://bitbucket.org/contrastsecurity/teamserver/pull-requests/10016

# Purpose
Add methods for getting enabled job outcome policies and enabled job outcome policies that apply to a specific application

# Context
These methods are needed by the Jenkins plugin.