### PR TITLE
removed appVersionTag and startDate to increase enforceability of the…

### DIFF
--- a/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -44,15 +44,6 @@ public class SecurityCheckForm {
     private AgentType agentLanguage;
 
     /**
-     * Filter the application's vulnerabilities using app version tags.
-     * Do not set if you want to verify against all of the application's vulnerabilities.
-     * @param appVersionTags New appVersionTags.
-     * @return The appVersionTags filter
-     */
-    @SerializedName("app_version_tags")
-    private List<String> appVersionTags;
-
-    /**
      * Where the request is being made
      * Default: OTHER
      * @param origin New origin for the security check
@@ -60,15 +51,6 @@ public class SecurityCheckForm {
      */
     @SerializedName("origin")
     private String origin = "OTHER";
-
-    /**
-     * Filter the application's vulnerabilities using start date in milliseconds.
-     * Do not set if you want to verify against all of the application's vulnerabilities.
-     * @param startDate New start date.
-     * @return The start date filter
-     */
-    @SerializedName("start_date")
-    private Long startDate;
 
     public SecurityCheckForm(String applicationId) {
         this.applicationId = applicationId;


### PR DESCRIPTION
# Problem

The Job outcome policy needs to be what defines the vulnerability selection.

# Solution

Remove filtering from security check in order to increase the job outcome policy enforce ability.

