### PR TITLE
Contrast 39999 add constructor with proxy default api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ This SDK gives you a quick start for programmatically accessing the [Contrast RE
 
 Code example:
 ```
-ContrastSDK contrastSDK = new ContrastSDK("test@test.com", "testServiceKey", "testApiKey", "https://apptwo.contrastsecurity.com/Contrast/api");
+ContrastSDK contrastSDK = new ContrastSDK.Builder("contrast_admin", "demo", "demo")
+        .withApiUrl("http://localhost:19080/Contrast/api")
+        .build();
 
 String orgUuid = contrastSDK.getProfileDefaultOrganizations().getOrganization().getOrgUuid();
 
@@ -52,3 +54,10 @@ Ticketbook (2K LOC)
 WebGoat (48K LOC)
 WebGoat7 (106K LOC)
 ```
+
+### Deprecation
+
+The old-style constructor `new ContrastSDK()` has been deprecated in version 2.15. Please migrate your code to use `new ContrastSDK.Builder()`
+
+We will remove the deprecated constructors in version 3.
+

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -98,7 +98,8 @@ public class ContrastSDK {
         }
 
         public Builder withApiUrl(String apiUrl) {
-            this.restApiURL = apiUrl;
+            ContrastSDKUtils.validateUrl(apiUrl);
+            this.restApiURL = ContrastSDKUtils.ensureApi(apiUrl);
             return this;
         }
 

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -81,19 +81,58 @@ public class ContrastSDK {
     private int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
     private int readTimeout = DEFAULT_READ_TIMEOUT;
 
+    public static class Builder {
+        private String user;
+        private String serviceKey;
+        private String apiKey;
+        private Proxy proxy;
+        private String restApiURL;
+
+        public Builder(String user, String serviceKey, String apiKey) {
+            this.user = user;
+            this.serviceKey = serviceKey;
+            this.apiKey = apiKey;
+            this.restApiURL = DEFAULT_API_URL;
+            ContrastSDKUtils.validateUrl(this.restApiURL);
+            this.proxy = Proxy.NO_PROXY;
+        }
+
+        public Builder withApiUrl(String apiUrl) {
+            this.restApiURL = apiUrl;
+            return this;
+        }
+
+        public Builder withProxy(Proxy proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        public ContrastSDK build() {
+            ContrastSDK sdk = new ContrastSDK(this.user, this.serviceKey, this.apiKey);
+            sdk.restApiURL = this.restApiURL;
+            sdk.proxy = this.proxy;
+            return sdk;
+        }
+    }
+
+    /**
+     * Use ContrastSDK.Builder
+     */
+    @Deprecated
     public ContrastSDK() {
 
     }
 
     /**
      * Create a ContrastSDK object to use the Contrast V3 API
-     *
+     * Deprecated - Please use builder
      * @param user       Username (e.g., joe@acme.com)
      * @param serviceKey User service key
      * @param apiKey     API Key
      * @param restApiURL the base Contrast API URL
      * @throws IllegalArgumentException if the API URL is malformed
      */
+    @Deprecated
     public ContrastSDK(String user, String serviceKey, String apiKey, String restApiURL) throws IllegalArgumentException {
         this.user = user;
         this.serviceKey = serviceKey;
@@ -110,7 +149,7 @@ public class ContrastSDK {
 
     /**
      * Create a ContrastSDK object to use the Contrast V3 API through a Proxy.
-     *
+     * Deprecated - Please use builder
      * @param user       Username (e.g., joe@acme.com)
      * @param serviceKey User service key
      * @param apiKey     API Key
@@ -118,6 +157,7 @@ public class ContrastSDK {
      * @param proxy Proxy to use
      * @throws IllegalArgumentException if the API URL is malformed
      */
+    @Deprecated
     public ContrastSDK(String user, String serviceKey, String apiKey, String restApiURL, Proxy proxy) throws IllegalArgumentException {
         this.user = user;
         this.serviceKey = serviceKey;
@@ -134,12 +174,14 @@ public class ContrastSDK {
 
     /**
      * Create a ContrastSDK object to use the Contrast V3 API
+     * Deprecated - Please use Builder
      * <p>
      * This will use the default api url which is https://app.contrastsecurity.com/Contrast/api
      * @param user Username (e.g., joe@acme.com)
      * @param serviceKey User service key
      * @param apiKey API Key
      */
+    @Deprecated
     public ContrastSDK(String user, String serviceKey, String apiKey) {
         this.user = user;
         this.serviceKey = serviceKey;
@@ -153,6 +195,7 @@ public class ContrastSDK {
 
     /**
      * Create a ContrastSDK object to use the Contrast V3 API through a Proxy.
+     * Deprecated - Please use builder.
      * <p>
      * This will use the default api url.
      * @param user       Username (e.g., joe@acme.com)
@@ -161,6 +204,7 @@ public class ContrastSDK {
      * @param proxy Proxy to use
      * @throws IllegalArgumentException if the API URL is malformed
      */
+    @Deprecated
     public ContrastSDK(String user, String serviceKey, String apiKey, Proxy proxy) throws IllegalArgumentException {
         this.user = user;
         this.serviceKey = serviceKey;

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -152,6 +152,30 @@ public class ContrastSDK {
     }
 
     /**
+     * Create a ContrastSDK object to use the Contrast V3 API through a Proxy.
+     * <p>
+     * This will use the default api url.
+     * @param user       Username (e.g., joe@acme.com)
+     * @param serviceKey User service key
+     * @param apiKey     API Key
+     * @param proxy Proxy to use
+     * @throws IllegalArgumentException if the API URL is malformed
+     */
+    public ContrastSDK(String user, String serviceKey, String apiKey, Proxy proxy) throws IllegalArgumentException {
+        this.user = user;
+        this.serviceKey = serviceKey;
+        this.apiKey = apiKey;
+        this.restApiURL = DEFAULT_API_URL;
+
+        ContrastSDKUtils.validateUrl(this.restApiURL);
+        this.restApiURL = ContrastSDKUtils.ensureApi(this.restApiURL);
+
+        this.urlBuilder = UrlBuilder.getInstance();
+        this.gson = new Gson();
+        this.proxy = proxy;
+    }
+
+    /**
      * Get all Assess Licensing for an Organizations.
      * @param organizationId the ID of the organization
      * @return AssessLicenseOverview with Assess Licensing for an Oeg.

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -195,32 +195,6 @@ public class ContrastSDK {
     }
 
     /**
-     * Create a ContrastSDK object to use the Contrast V3 API through a Proxy.
-     * Deprecated - Please use builder.
-     * <p>
-     * This will use the default api url.
-     * @param user       Username (e.g., joe@acme.com)
-     * @param serviceKey User service key
-     * @param apiKey     API Key
-     * @param proxy Proxy to use
-     * @throws IllegalArgumentException if the API URL is malformed
-     */
-    @Deprecated
-    public ContrastSDK(String user, String serviceKey, String apiKey, Proxy proxy) throws IllegalArgumentException {
-        this.user = user;
-        this.serviceKey = serviceKey;
-        this.apiKey = apiKey;
-        this.restApiURL = DEFAULT_API_URL;
-
-        ContrastSDKUtils.validateUrl(this.restApiURL);
-        this.restApiURL = ContrastSDKUtils.ensureApi(this.restApiURL);
-
-        this.urlBuilder = UrlBuilder.getInstance();
-        this.gson = new Gson();
-        this.proxy = proxy;
-    }
-
-    /**
      * Get all Assess Licensing for an Organizations.
      * @param organizationId the ID of the organization
      * @return AssessLicenseOverview with Assess Licensing for an Oeg.


### PR DESCRIPTION
Implemented a builder pattern to combat too many parameters to constructors.

Marked constructors as deprecated to encourage use of the builder.