### PR TITLE
CUST-2645 - Added ApplicationFilter Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.contrastsecurity</groupId>
     <artifactId>contrast-sdk-java</artifactId>
-    <version>2.16-SNAPSHOT</version>
+    <version>2.17-SNAPSHOT</version>
     
     <organization>
         <name>Contrast Security</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.contrastsecurity</groupId>
     <artifactId>contrast-sdk-java</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>2.16-SNAPSHOT</version>
     
     <organization>
         <name>Contrast Security</name>

--- a/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
@@ -1,0 +1,243 @@
+package com.contrastsecurity.http;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+public class ApplicationFilterForm extends FilterForm {
+
+    public enum ApplicationExpandValues {
+        COMPLIANCE_POLICY, COVERAGE, LICENSE, MODULES, PRODUCTION_PROTECTED, SCORES, SKIP_LINKS, TECHNOLOGIES, TRACE_BREAKDOWN;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
+    }
+
+    public enum ApplicationQuickFilterType {
+        ALL("all"),
+        ONLINE("online"),
+        OFFLINE("offline"),
+        MERGED("merged"),
+        LICENSED("licensed"),
+        UNLICENSED("unlicensed"),
+        HIGH_RISK("high-risk"),
+        INCOMPLETE_PROTECTION("incomplete-protection"),
+        VIOLATION("violation"),
+        ARCHIVED("archived");
+
+        private final String name;
+
+        ApplicationQuickFilterType(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    private String filterText;
+    private String filterAppCode;
+    private List<String> filterServers;
+    private List<String> filterTechs;
+    private List<String> filterTags;
+    private List<String> filterCompliance;
+    private List<String> filterLanguages;
+    private EnumSet<ServerEnvironment> environment;
+    private EnumSet<RuleSeverity> filterVulnSeverities;
+    private boolean includeArchived;
+    private boolean includeOnlyLicensed;
+    private boolean includeMerged;
+    private ApplicationQuickFilterType quickFilter;
+
+    public ApplicationFilterForm() {
+        super();
+        this.filterText = "";
+        this.filterAppCode = "";
+        this.filterServers = new ArrayList<>();
+        this.filterTechs = new ArrayList<>();
+        this.filterTags = new ArrayList<>();
+        this.filterLanguages = new ArrayList<>();
+        this.filterCompliance = new ArrayList<>();
+        this.environment = null;
+        this.filterVulnSeverities = null;
+        this.includeArchived = false;
+        this.includeOnlyLicensed = false;
+        this.quickFilter = null;
+        this.includeMerged = true;
+    }
+
+    public String getFilterText() {
+        return filterText;
+    }
+
+    public void setFilterText(String filterText) {
+        this.filterText = filterText;
+    }
+
+    public String getFilterAppCode() {
+        return filterAppCode;
+    }
+
+    public void setFilterAppCode(String filterAppCode) {
+        this.filterAppCode = filterAppCode;
+    }
+
+    public List<String> getFilterServers() {
+        return filterServers;
+    }
+
+    public void setFilterServers(List<String> filterServers) {
+        this.filterServers = filterServers;
+    }
+
+    public List<String> getFilterTechs() {
+        return filterTechs;
+    }
+
+    public void setFilterTechs(List<String> filterTechs) {
+        this.filterTechs = filterTechs;
+    }
+
+    public List<String> getFilterTags() {
+        return filterTags;
+    }
+
+    public void setFilterTags(List<String> filterTags) {
+        this.filterTags = filterTags;
+    }
+
+    public List<String> getFilterLanguages() {
+        return filterLanguages;
+    }
+
+    public void setFilterLanguages(List<String> filterLanguages) {
+        this.filterLanguages = filterLanguages;
+    }
+
+    public List<String> getFilterCompliance() {
+        return filterCompliance;
+    }
+
+    public void setFilterCompliance(List<String> filterCompliance) {
+        this.filterCompliance = filterCompliance;
+    }
+
+    public EnumSet<ServerEnvironment> getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(EnumSet<ServerEnvironment> environment) {
+        this.environment = environment;
+    }
+
+    public EnumSet<RuleSeverity> getFilterVulnSeverities() {
+        return filterVulnSeverities;
+    }
+
+    public void setFilterVulnSeverities(EnumSet<RuleSeverity> filterVulnSeverities) {
+        this.filterVulnSeverities = filterVulnSeverities;
+    }
+
+    public boolean getIncludeArchived() {
+        return includeArchived;
+    }
+
+    public void setIncludeArchived(boolean includeArchived) {
+        this.includeArchived = includeArchived;
+    }
+
+    public boolean isIncludeOnlyLicensed() {
+        return includeOnlyLicensed;
+    }
+
+    public void setIncludeOnlyLicensed(boolean includeOnlyLicensed) {
+        this.includeOnlyLicensed = includeOnlyLicensed;
+    }
+
+    public ApplicationQuickFilterType getQuickFilter() {
+        return quickFilter;
+    }
+
+    public void setQuickFilter(ApplicationQuickFilterType quickFilter) {
+        this.quickFilter = quickFilter;
+    }
+
+    public boolean isIncludeMerged() {
+        return includeMerged;
+    }
+
+    public void setIncludeMerged(boolean includeMerged) {
+        this.includeMerged = includeMerged;
+    }
+
+    @Override
+    public String toString() {
+        String formString = super.toString();
+
+        List<String> filters = new ArrayList<>();
+
+        if (StringUtils.isNotEmpty(filterText)) {
+            filters.add("filterText=" + filterText);
+        }
+
+        if (StringUtils.isNotEmpty(filterAppCode)) {
+            filters.add("filterAppCode=" + filterAppCode);
+        }
+
+        if (!filterServers.isEmpty()) {
+            filters.add("filterServers=" + StringUtils.join(filterServers, ","));
+        }
+
+        if (!filterTechs.isEmpty()) {
+            filters.add("filterTechs=" + StringUtils.join(filterTechs, ","));
+        }
+
+        if (!filterTags.isEmpty()) {
+            filters.add("filterTags=" + StringUtils.join(filterTags, ","));
+        }
+
+        if (!filterCompliance.isEmpty()) {
+            filters.add("filterCompliance=" + StringUtils.join(filterCompliance, ","));
+        }
+
+        if (!filterLanguages.isEmpty()) {
+            filters.add("filterLanguages=" + StringUtils.join(filterLanguages, ","));
+        }
+
+        if (environment != null && !environment.isEmpty()) {
+            filters.add("environments=" + StringUtils.join(environment, ","));
+        }
+
+        if (filterVulnSeverities != null && !filterVulnSeverities.isEmpty()) {
+            filters.add("filterVulnSeverities=" + StringUtils.join(filterVulnSeverities, ","));
+        }
+
+        filters.add("includeArchived=" + includeArchived);
+        filters.add("includeOnlyLicensed=" + includeOnlyLicensed);
+        filters.add("includeMerged=" + includeMerged);
+
+        if (quickFilter != null) {
+            filters.add("quickFilter=" + quickFilter.toString());
+        }
+
+        String result;
+
+        if (!filters.isEmpty()) {
+            result = StringUtils.join(filters, "&");
+        } else {
+            return formString;
+        }
+
+        if (StringUtils.isNotEmpty(formString)) {
+            return formString + "&" + result;
+        } else {
+            return "?" + result;
+        }
+    }
+}

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -35,6 +35,10 @@ public class UrlBuilder {
         return String.format("/ng/%s/applications/%s%s", organizationId, appId, buildExpand(expandValues));
     }
 
+    public String getApplicationFilterUrl(String organizationId, ApplicationFilterForm applicationFilterForm) {
+        return String.format("/ng/%s/applications/filter%s", organizationId, applicationFilterForm.toString());
+    }
+
     public String getCreateApplicationUrl(String organizationId) {
         return String.format("/ng/integrations/organizations/%s/applications", organizationId);
     }

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -30,18 +30,7 @@ package com.contrastsecurity.sdk;
 
 import com.contrastsecurity.exceptions.ApplicationCreateException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
-import com.contrastsecurity.http.FilterForm;
-import com.contrastsecurity.http.HttpMethod;
-import com.contrastsecurity.http.JobOutcomePolicyListResponse;
-import com.contrastsecurity.http.MediaType;
-import com.contrastsecurity.http.RequestConstants;
-import com.contrastsecurity.http.SecurityCheckForm;
-import com.contrastsecurity.http.SecurityCheckResponse;
-import com.contrastsecurity.http.ServerFilterForm;
-import com.contrastsecurity.http.TraceFilterForm;
-import com.contrastsecurity.http.TraceFilterKeycode;
-import com.contrastsecurity.http.TraceFilterType;
-import com.contrastsecurity.http.UrlBuilder;
+import com.contrastsecurity.http.*;
 import com.contrastsecurity.models.*;
 import com.contrastsecurity.models.dtm.ApplicationCreateRequest;
 import com.contrastsecurity.models.dtm.AttestationCreateRequest;
@@ -480,6 +469,28 @@ public class ContrastSDK {
         InputStreamReader reader = null;
         try {
             is = makeRequest(HttpMethod.GET, urlBuilder.getApplicationsUrl(organizationId));
+            reader = new InputStreamReader(is);
+            return this.gson.fromJson(reader, Applications.class);
+        } finally {
+            IOUtils.closeQuietly(reader);
+            IOUtils.closeQuietly(is);
+        }
+    }
+
+    /**
+     * Get the list of filtered applications being monitored by Contrast.
+     *
+     * @param organizationId the ID of the organization
+     * @param applicationFilterForm  Query params to add more info to response
+     * @return Applications object that contains the list of Application's
+     * @throws UnauthorizedException if the Contrast account failed to authorize
+     * @throws IOException           if there was a communication problem
+     */
+    public Applications getFilteredApplications(String organizationId, ApplicationFilterForm applicationFilterForm) throws UnauthorizedException, IOException {
+        InputStream is = null;
+        InputStreamReader reader = null;
+        try {
+            is = makeRequest(HttpMethod.GET, urlBuilder.getApplicationFilterUrl(organizationId, applicationFilterForm));
             reader = new InputStreamReader(is);
             return this.gson.fromJson(reader, Applications.class);
         } finally {

--- a/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
@@ -73,6 +73,7 @@ public class ApplicationFilterFilterFormTest {
         assertTrue(qs.contains("filterTechs"));
         assertTrue(qs.contains("filterText"));
         assertTrue(qs.contains("filterVulnSeverities"));
+        assertTrue(qs.contains("environment"));
         assertTrue(qs.contains("quickFilter"));
 
         assertTrue(qs.contains("includeArchived"));

--- a/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
@@ -1,0 +1,104 @@
+package com.contrastsecurity;
+
+
+import com.contrastsecurity.http.ApplicationFilterForm;
+import com.contrastsecurity.http.FilterForm;
+import com.contrastsecurity.http.RuleSeverity;
+import com.contrastsecurity.http.ServerEnvironment;
+import com.sun.tools.javac.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ApplicationFilterFilterFormTest {
+
+    ApplicationFilterForm filterForm;
+
+    @Before
+    public void setUp() {
+        filterForm = new ApplicationFilterForm();
+    }
+
+    @Test
+    public void testBasicForm() {
+        filterForm.setLimit(10);
+        filterForm.setOffset(10);
+        filterForm.setStatus("Reported");
+
+        String qs = filterForm.toString();
+
+        assertFalse(qs.isEmpty());
+
+        assertTrue(qs.contains("limit"));
+        assertTrue(qs.contains("offset"));
+        assertTrue(qs.contains("status"));
+        assertFalse(qs.contains("sort"));
+        assertFalse(qs.contains("startDate"));
+    }
+
+    @Test
+    public void testValuesForm() {
+        filterForm.setEnvironment(EnumSet.of(ServerEnvironment.DEVELOPMENT));
+
+        filterForm.setFilterAppCode("test_app_code");
+        filterForm.setFilterCompliance(List.of("owasp"));
+        filterForm.setFilterLanguages(List.of("Java"));
+        filterForm.setFilterServers(List.of("abcdefg"));
+        filterForm.setFilterTags(List.of("tag1"));
+        filterForm.setFilterTechs(List.of("MySQL"));
+        filterForm.setFilterText("test");
+        filterForm.setFilterVulnSeverities(EnumSet.of(RuleSeverity.CRITICAL));
+        filterForm.setEnvironment(EnumSet.of(ServerEnvironment.DEVELOPMENT));
+        filterForm.setIncludeArchived(false);
+        filterForm.setIncludeMerged(false);
+        filterForm.setIncludeOnlyLicensed(true);
+
+        filterForm.setQuickFilter(ApplicationFilterForm.ApplicationQuickFilterType.ALL);
+
+        String qs = filterForm.toString();
+
+        assertFalse(qs.isEmpty());
+
+        assertTrue(qs.contains("filterAppCode"));
+        assertTrue(qs.contains("filterCompliance"));
+        assertTrue(qs.contains("filterLanguages"));
+        assertTrue(qs.contains("filterServers"));
+        assertTrue(qs.contains("filterTags"));
+        assertTrue(qs.contains("filterTechs"));
+        assertTrue(qs.contains("filterText"));
+        assertTrue(qs.contains("filterVulnSeverities"));
+        assertTrue(qs.contains("quickFilter"));
+
+        assertTrue(qs.contains("includeArchived"));
+        assertTrue(qs.contains("includeMerged"));
+        assertTrue(qs.contains("includeOnlyLicensed"));
+
+    }
+
+    @Test
+    public void testExpand() {
+        EnumSet<FilterForm.ApplicationExpandValues> expand = EnumSet.of(FilterForm.ApplicationExpandValues.SCORES, FilterForm.ApplicationExpandValues.LICENSE);
+
+        filterForm.setExpand(expand);
+
+        String qs = filterForm.toString();
+
+        assertFalse(qs.isEmpty());
+
+        assertTrue(qs.contains("expand"));
+
+        String expandValues = qs.split("=")[1];
+        ArrayList<String> values = new ArrayList<>(Arrays.asList(expandValues.split(",")));
+
+        assertTrue(values.contains("scores"));
+        assertFalse(values.contains("apps"));
+        assertFalse(values.contains("test"));
+        assertFalse(values.contains("libs"));
+    }
+}

--- a/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
@@ -5,7 +5,6 @@ import com.contrastsecurity.http.ApplicationFilterForm;
 import com.contrastsecurity.http.FilterForm;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
-import com.sun.tools.javac.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,11 +46,11 @@ public class ApplicationFilterFilterFormTest {
         filterForm.setEnvironment(EnumSet.of(ServerEnvironment.DEVELOPMENT));
 
         filterForm.setFilterAppCode("test_app_code");
-        filterForm.setFilterCompliance(List.of("owasp"));
-        filterForm.setFilterLanguages(List.of("Java"));
-        filterForm.setFilterServers(List.of("abcdefg"));
-        filterForm.setFilterTags(List.of("tag1"));
-        filterForm.setFilterTechs(List.of("MySQL"));
+        filterForm.setFilterCompliance(Arrays.asList("owasp"));
+        filterForm.setFilterLanguages(Arrays.asList("Java"));
+        filterForm.setFilterServers(Arrays.asList("abcdefg"));
+        filterForm.setFilterTags(Arrays.asList("tag1"));
+        filterForm.setFilterTechs(Arrays.asList("MySQL"));
         filterForm.setFilterText("test");
         filterForm.setFilterVulnSeverities(EnumSet.of(RuleSeverity.CRITICAL));
         filterForm.setEnvironment(EnumSet.of(ServerEnvironment.DEVELOPMENT));

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -62,6 +62,20 @@ public class ContrastSDKTest extends ContrastSDK {
     }
 
     @Test
+    public void testGetFilteredApplications() throws UnauthorizedException, IOException, ResourceNotFoundException {
+
+        String applicationsString = "{\"applications\":[{\"app_id\":\"72358543-bbdb-490c-8e3f-1b5f5e9a0bf7\",\"archived\":false,\"created\":1461631080000,\"status\":\"offline\",\"path\":\"/Curl\",\"name\":\"Contrast-Curl\",\"language\":\"Java\",\"last_seen\":1461631080000,\"total_modules\":1,\"master\":false},{\"app_id\":\"b9acb026-36a6-4f4e-b568-33168b7a5ae6\",\"archived\":false,\"created\":1460582653000,\"status\":\"offline\",\"path\":\"/portal\",\"name\":\"portal\",\"language\":\"Java\",\"last_seen\":1460925180000,\"total_modules\":1,\"master\":false},{\"app_id\":\"53775e84-90a6-4a64-bafe-2b153c3a40f0\",\"archived\":false,\"created\":1460582640000,\"status\":\"offline\",\"path\":\"/\",\"name\":\"ROOT\",\"language\":\"Java\",\"last_seen\":1460925180000,\"total_modules\":1,\"master\":false},{\"app_id\":\"9e88815f-bb0d-44b4-ac5a-f02f661e8947\",\"archived\":false,\"created\":1460582659000,\"status\":\"offline\",\"path\":\"/library\",\"name\":\"sakai-library\",\"language\":\"Java\",\"last_seen\":1460925180000,\"total_modules\":1,\"master\":false},{\"app_id\":\"e9a14797-42e7-4ba4-8282-364fdf37026c\",\"archived\":false,\"created\":1460582916000,\"status\":\"offline\",\"path\":\"/sakai-user-tool\",\"name\":\"sakai-user-tool\",\"language\":\"Java\",\"last_seen\":1460925180000,\"total_modules\":2,\"master\":true},{\"app_id\":\"469b9147-5736-4b83-9158-657427d4c960\",\"archived\":false,\"created\":1461600682000,\"status\":\"offline\",\"path\":\"/examples\",\"name\":\"Servlet and JSP Examples\",\"language\":\"Java\",\"last_seen\":1461737160000,\"total_modules\":1,\"master\":false},{\"app_id\":\"3da856f4-c508-48b8-95a9-514eddefcbf3\",\"archived\":false,\"created\":1461599820000,\"status\":\"offline\",\"path\":\"/WebGoat\",\"name\":\"WebGoat\",\"language\":\"Java\",\"last_seen\":1461737160000,\"total_modules\":1,\"master\":false}]}";
+
+        Applications apps = gson.fromJson(applicationsString, Applications.class);
+
+        assertNotNull(apps);
+        assertNotNull(apps.getApplications());
+
+        assertNull(apps.getApplication());
+        assertTrue(!apps.getApplications().isEmpty());
+    }
+
+    @Test
     public void testGetApplicationsWithMetadata() throws UnauthorizedException, IOException, ResourceNotFoundException, InvalidConversionException {
 
         String applicationsString = "{\"applications\":[{\"app_id\":\"72358543-bbdb-490c-8e3f-1b5f5e9a0bf7\",\"archived\":false,\"created\":1461631080000,\"status\":\"offline\",\"path\":\"/Curl\",\"name\":\"Contrast-Curl\",\"language\":\"Java\",\"last_seen\":1461631080000,\"total_modules\":1,\"master\":false, \"metadataEntities\": [ { \"fieldName\": \"Contact\", \"fieldValue\": \"\", \"type\": \"PERSON_OF_CONTACT\", \"unique\": false, \"subfields\": [ { \"fieldName\": \"Contact Name\", \"fieldValue\": \"Contrast User\", \"type\": \"CONTACT_NAME\" }, { \"fieldName\": \"Contact Email\", \"fieldValue\": \"support@contrastsecurity.com\", \"type\": \"EMAIL\" }, { \"fieldName\": \"Contact Phone\", \"fieldValue\": \"1234567890\", \"type\": \"PHONE\" } ] }, { \"fieldName\": \"bU\", \"fieldValue\": \"PEDS\", \"type\": \"STRING\" }, {\"fieldName\": \"askId\", \"fieldValue\": \"123456789\", \"type\": \"NUMERIC\" }]}, ,{\"app_id\":\"9e88815f-bb0d-44b4-ac5a-f02f661e8947\",\"archived\":false,\"created\":1460582659000,\"status\":\"offline\",\"path\":\"/library\",\"name\":\"sakai-library\",\"language\":\"Java\",\"last_seen\":1460925180000,\"total_modules\":1,\"master\":false}]}";

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -30,7 +30,7 @@ public class ContrastSDKTest extends ContrastSDK {
 
     @BeforeClass
     public static void setUp() {
-        contrastSDK = new ContrastSDK("test_user", "testApiKey", "testServiceKey", "http://localhost:19080/Contrast/api", Proxy.NO_PROXY);
+        contrastSDK = new ContrastSDK.Builder("test_user", "testApiKey", "testServiceKey").withApiUrl("http://localhost:19080/Contrast/api").build();
         gson = new GsonBuilder()
                 .registerTypeAdapter(MetadataEntity.class, new MetadataDeserializer()).create();;
     }

--- a/src/test/java/com/contrastsecurity/FilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/FilterFormTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -30,7 +29,7 @@ public class FilterFormTest {
 
         String qs = filterForm.toString();
 
-        assertTrue(!qs.isEmpty());
+        assertFalse(qs.isEmpty());
 
         assertTrue(qs.contains("limit"));
         assertTrue(qs.contains("offset"));
@@ -47,7 +46,7 @@ public class FilterFormTest {
 
         String qs = filterForm.toString();
 
-        assertTrue(!qs.isEmpty());
+        assertFalse(qs.isEmpty());
 
         assertTrue(qs.contains("expand"));
 

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -1,5 +1,6 @@
 package com.contrastsecurity;
 
+import com.contrastsecurity.http.ApplicationFilterForm;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.http.UrlBuilder;
 import com.contrastsecurity.models.AgentType;
@@ -40,6 +41,17 @@ public class UrlBuilderTest {
         String expectedUrl = "/ng/test-org/applications/test-app";
 
         assertEquals(expectedUrl, urlBuilder.getApplicationUrl(organizationId, applicationId, null));
+    }
+
+    @Test
+    public void testFilterApplicationUrl() {
+        String expectedUrl = "/ng/test-org/applications/filter?expand=license&includeArchived=false&includeOnlyLicensed=false&includeMerged=true";
+
+        ApplicationFilterForm form = new ApplicationFilterForm();
+
+        form.setExpand(EnumSet.of(ApplicationFilterForm.ApplicationExpandValues.LICENSE));
+
+        assertEquals(expectedUrl, urlBuilder.getApplicationFilterUrl(organizationId, form));
     }
 
     @Test


### PR DESCRIPTION
As a user of the Contrast Java SDK I'd like to be able to use a method to call the following endpoint -> `/ng/{orgUuid}/applications/filter`.

I added a ScreenerTest to verify and did manual testing with the endpoint.