### PR TITLE
👷 JAVA-3136 Migrate Lombok from Runtime Dependency to Compile Only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.18</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
The lombok dependency should always use `<scope>provided</scope>` in a Maven project, because it is not a dependency users need at runtime. Rather, this project only needs Lombok at compile time to use its annotation processor.