### PR TITLE
🔥 JAVA-3132 Remove JAXB Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,21 +83,6 @@
             <version>1.18.18</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/contrastsecurity/models/CodeObject.java
+++ b/src/main/java/com/contrastsecurity/models/CodeObject.java
@@ -29,12 +29,15 @@
 
 package com.contrastsecurity.models;
 
-import javax.xml.bind.DatatypeConverter;
-
 /**
  * Represents a primitive/object in a method invocation. The parameters, "this", and return value
  * are modeled with this object.
+ *
+ * @deprecated because this object contains accessors for fields that can never be set. At best it's
+ *     not useful and at worst it produces {@code NullPointerException}. It was drafted 7 years ago
+ *     and never used.
  */
+@Deprecated
 public class CodeObject {
 
   /**
@@ -65,7 +68,7 @@ public class CodeObject {
    * @return the value of the object
    */
   public String getValue() {
-    return DatatypeConverter.printBase64Binary(value.getBytes()).trim();
+    throw new NullPointerException("value is always null");
   }
 
   private String value;


### PR DESCRIPTION
Contrast SDK includes JAXB as a compile time dependency. Since JAXB was included in JDKs prior to JDK 11, this is a problematic dependency to force our users to take. It’s very likely to cause conflicts that users will have to deconflict using tedious Maven and Gradle configuration.

We only use JAXB for a base64 utility. The method that uses the utility always throws `NullPointerException`. The class to which this method belongs was drafted 7 years ago and never used. Marking it as deprecating.