### PR TITLE
Spotless check for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,17 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: GPG_PASSPHRASE
       - name: validate
         run: mvn clean test
-
       - name: import gpg
         run: |
           echo ${{secrets.GPG_SECRET_KEYS}} | base64 --decode | gpg --import --no-tty --batch --yes

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.contrastsecurity</groupId>
     <artifactId>contrast-sdk-java</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.1</version>
 
     <organization>
         <name>Contrast Security</name>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</connection>
         <url>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</url>
         <developerConnection>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>contrast-sdk-java-3.1</tag>
   </scm>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.contrastsecurity</groupId>
     <artifactId>contrast-sdk-java</artifactId>
-    <version>3.1</version>
+    <version>3.2-SNAPSHOT</version>
 
     <organization>
         <name>Contrast Security</name>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</connection>
         <url>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</url>
         <developerConnection>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</developerConnection>
-      <tag>contrast-sdk-java-3.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>


### PR DESCRIPTION
This updates the jdk version to 11 for the publish step so that we can run the spotless test in the publish workflow