### PR TITLE
Use java.util.Base64 instead of commons-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
             <version>1.7.2</version>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>

--- a/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
+++ b/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.EnumSet;
 import java.util.List;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 
 public class ContrastSDKUtils {
@@ -20,7 +20,7 @@ public class ContrastSDKUtils {
       throws IOException {
     String token = username.trim() + ":" + serviceKey.trim();
 
-    return Base64.encodeBase64String(token.trim().getBytes("UTF-8")).trim();
+    return Base64.getEncoder().encodeToString(token.trim().getBytes("UTF-8")).trim();
   }
 
   public static void validateUrl(String url) throws IllegalArgumentException {


### PR DESCRIPTION
Use standard library instead of `commons-codec` which drops a dependency.
Since the library is supported on JDK 8 or newer this should be ok to do.