### PR TITLE
Prevent Duplicate Trigger but still allow pull requests from forked repositories to be verified.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Changed on push trigger to only trigger on the main branch. Pull request still triggers on all.

This allows the build to trigger when a pull request from a forked repo is opened and prevents duplicate triggers on our pull request.

down side is that pushing to feature branches doesn't trigger the build action. I think this is fine. Verification is only needed when you are ready to merge.