### PR TITLE
Add support for organization and application libraries filter APIs

### DIFF
--- a/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
@@ -1,0 +1,197 @@
+package com.contrastsecurity.http;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+
+public class LibraryFilterForm extends FilterForm {
+
+  public enum LibraryExpandValues {
+    VULNS,
+    APPS,
+    MANIFEST,
+    STATUS,
+    SKIP_LINKS;
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+
+  public enum LibraryQuickFilterType {
+    ALL,
+    VULNERABLE,
+    VIOLATION,
+    PRIVATE,
+    PUBLIC,
+    HIGH_RISK;
+
+    @Override
+    public String toString() {
+      return name();
+    }
+  }
+
+  private List<String> apps;
+  private List<Long> servers;
+  private List<String> tags;
+  private String q;
+  private List<String> languages;
+  private List<String> licenses;
+  private List<String> grades;
+  private LibraryQuickFilterType quickFilter;
+  private boolean includeUsed;
+  private boolean includeUnused;
+
+  public LibraryFilterForm() {
+    super();
+
+    this.apps = new ArrayList<>();
+    this.servers = new ArrayList<>();
+    this.tags = new ArrayList<>();
+    this.q = "";
+    this.languages = new ArrayList<>();
+    this.licenses = new ArrayList<>();
+    this.grades = new ArrayList<>();
+    this.quickFilter = null;
+    this.includeUsed = false;
+    this.includeUnused = false;
+  }
+
+  public List<String> getApps() {
+    return apps;
+  }
+
+  public void setApps(List<String> apps) {
+    this.apps = apps;
+  }
+
+  public List<Long> geServers() {
+    return servers;
+  }
+
+  public void setServers(List<Long> servers) {
+    this.servers = servers;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public String getQ() {
+    return q;
+  }
+
+  public void setQ(String q) {
+    this.q = q;
+  }
+
+  public List<String> getLanguages() {
+    return languages;
+  }
+
+  public void setLanguages(List<String> languages) {
+    this.languages = languages;
+  }
+
+  public List<String> getLicenses() {
+    return licenses;
+  }
+
+  public void setLicenses(List<String> licenses) {
+    this.licenses = licenses;
+  }
+
+  public List<String> getGrades() {
+    return grades;
+  }
+
+  public void setGrades(List<String> grades) {
+    this.grades = grades;
+  }
+
+  public LibraryQuickFilterType getQuickFilter() {
+    return quickFilter;
+  }
+
+  public void setQuickFilter(LibraryQuickFilterType quickFilter) {
+    this.quickFilter = quickFilter;
+  }
+
+  public boolean isIncludeUsed() {
+    return includeUsed;
+  }
+
+  public void setIncludeUsed(boolean includeUsed) {
+    this.includeUsed = includeUsed;
+  }
+
+  public boolean isIncludeUnused() {
+    return includeUnused;
+  }
+
+  public void setIncludeUnused(boolean includeUnused) {
+    this.includeUnused = includeUnused;
+  }
+
+  @Override
+  public String toString() {
+    String formString = super.toString();
+
+    List<String> filters = new ArrayList<>();
+
+    if (!apps.isEmpty()) {
+      filters.add("apps=" + StringUtils.join(apps, ","));
+    }
+
+    if (!servers.isEmpty()) {
+      filters.add("servers=" + StringUtils.join(servers, ","));
+    }
+
+    if (!tags.isEmpty()) {
+      filters.add("tags=" + StringUtils.join(tags, ","));
+    }
+
+    if (!StringUtils.isEmpty(q)) {
+      filters.add("q=" + q);
+    }
+
+    if (!languages.isEmpty()) {
+      filters.add("languages=" + StringUtils.join(languages, ","));
+    }
+
+    if (!licenses.isEmpty()) {
+      filters.add("licenses=" + StringUtils.join(licenses, ","));
+    }
+
+    if (!grades.isEmpty()) {
+      filters.add("grades=" + StringUtils.join(grades, ","));
+    }
+
+    if (quickFilter != null) {
+      filters.add("quickFilter=" + quickFilter.toString());
+    }
+
+    filters.add("includeUsed=" + includeUsed);
+    filters.add("includeUnused=" + includeUnused);
+
+    String result;
+
+    if (!filters.isEmpty()) {
+      result = StringUtils.join(filters, "&");
+    } else {
+      return formString;
+    }
+
+    if (StringUtils.isNotEmpty(formString)) {
+      return formString + "&" + result;
+    } else {
+      return "?" + result;
+    }
+  }
+}

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -82,10 +82,26 @@ public class UrlBuilder {
         "/ng/%s/applications/%s/route/filter?expand=observations", organizationId, appId);
   }
 
+  public String getLibrariesUrl(String organizationId, FilterForm form) {
+    String formString = form == null ? "" : form.toString();
+    return String.format("/ng/%s/libraries%s", organizationId, formString);
+  }
+
   public String getLibrariesUrl(
       String organizationId, String appId, EnumSet<FilterForm.LibrariesExpandValues> expandValues) {
     return String.format(
         "/ng/%s/applications/%s/libraries%s", organizationId, appId, buildExpand(expandValues));
+  }
+
+  public String getLibrariesFilterUrl(String organizationId, FilterForm form) {
+    String formString = form == null ? "" : form.toString();
+    return String.format("/ng/%s/libraries/filter%s", organizationId, formString);
+  }
+
+  public String getLibrariesFilterUrl(String organizationId, String appId, FilterForm form) {
+    String formString = form == null ? "" : form.toString();
+    return String.format(
+        "/ng/%s/applications/%s/libraries/filter%s", organizationId, appId, formString);
   }
 
   public String getLibraryStatsUrl(String organizationId) {

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -609,6 +609,55 @@ public class ContrastSDK {
     }
   }
 
+  /**
+   * Return the libraries of the Contrast organization.
+   *
+   * @param organizationId the ID of the organization
+   * @param filterForm FilterForm query parameters
+   * @return Libraries object that contains the list of Library objects
+   * @throws UnauthorizedException if the Contrast account failed to authorize
+   * @throws IOException if there was a communication problem
+   */
+  public Libraries getLibraries(String organizationId, LibraryFilterForm filterForm)
+      throws IOException, UnauthorizedException {
+    InputStream is = null;
+    InputStreamReader reader = null;
+    try {
+      is = makeRequest(HttpMethod.GET, urlBuilder.getLibrariesUrl(organizationId, filterForm));
+      reader = new InputStreamReader(is);
+
+      return this.gson.fromJson(reader, Libraries.class);
+    } finally {
+      IOUtils.closeQuietly(is);
+      IOUtils.closeQuietly(reader);
+    }
+  }
+
+  /**
+   * Return the libraries of the Contrast organization.
+   *
+   * @param organizationId the ID of the organization
+   * @param filterForm FilterForm query parameters
+   * @return Libraries object that contains the list of Library objects
+   * @throws UnauthorizedException if the Contrast account failed to authorize
+   * @throws IOException if there was a communication problem
+   */
+  public Libraries getLibrariesWithFilter(String organizationId, LibraryFilterForm filterForm)
+      throws IOException, UnauthorizedException {
+    InputStream is = null;
+    InputStreamReader reader = null;
+    try {
+      is =
+          makeRequest(HttpMethod.GET, urlBuilder.getLibrariesFilterUrl(organizationId, filterForm));
+      reader = new InputStreamReader(is);
+
+      return this.gson.fromJson(reader, Libraries.class);
+    } finally {
+      IOUtils.closeQuietly(is);
+      IOUtils.closeQuietly(reader);
+    }
+  }
+
   public Libraries getLibraries(String organizationId, String appId)
       throws IOException, UnauthorizedException {
     return getLibraries(organizationId, appId, null);
@@ -633,6 +682,34 @@ public class ContrastSDK {
       is =
           makeRequest(
               HttpMethod.GET, urlBuilder.getLibrariesUrl(organizationId, appId, expandValues));
+      reader = new InputStreamReader(is);
+
+      return this.gson.fromJson(reader, Libraries.class);
+    } finally {
+      IOUtils.closeQuietly(is);
+      IOUtils.closeQuietly(reader);
+    }
+  }
+
+  /**
+   * Return the libraries of the monitored Contrast application.
+   *
+   * @param organizationId the ID of the organization
+   * @param appId the ID of the application
+   * @param filterForm FilterForm query parameters
+   * @return Libraries object that contains the list of Library objects
+   * @throws UnauthorizedException if the Contrast account failed to authorize
+   * @throws IOException if there was a communication problem
+   */
+  public Libraries getLibrariesWithFilter(
+      String organizationId, String appId, LibraryFilterForm filterForm)
+      throws IOException, UnauthorizedException {
+    InputStream is = null;
+    InputStreamReader reader = null;
+    try {
+      is =
+          makeRequest(
+              HttpMethod.GET, urlBuilder.getLibrariesFilterUrl(organizationId, appId, filterForm));
       reader = new InputStreamReader(is);
 
       return this.gson.fromJson(reader, Libraries.class);


### PR DESCRIPTION
This adds support for the following APIs:

* `/ng/{orgUid}/libraries`
* `/ng/{orgUid}/libraries/filter`
* `/ng/{orgUid}/applications/{appId}/libraries/filter`