### PR TITLE
⬆️ JAVA-3298 Migrate to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,16 +37,14 @@
 
   <properties>
     <localTeamServerUrl>http://localhost:19080/Contrast/api</localTeamServerUrl>
+    <versions.maven-source-plugin>3.0.1</versions.maven-source-plugin>
+    <versions.maven-javadoc-plugin>3.0.0</versions.maven-javadoc-plugin>
+    <versions.maven-gpg-plugin>1.6</versions.maven-gpg-plugin>
+    <versions.nexus-staging-maven-plugin>1.6.8</versions.nexus-staging-maven-plugin>
+    <versions.junit-jupiter>5.7.1</versions.junit-jupiter>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -67,6 +65,19 @@
       <artifactId>gson</artifactId>
       <version>2.6.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${versions.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${versions.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,12 @@
       <version>${versions.junit-jupiter}</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.19.0</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
@@ -1,7 +1,6 @@
 package com.contrastsecurity;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrastsecurity.http.ApplicationFilterForm;
 import com.contrastsecurity.http.FilterForm;
@@ -30,13 +29,13 @@ final class ApplicationFilterFilterFormTest {
 
     String qs = filterForm.toString();
 
-    assertFalse(qs.isEmpty());
+    assertThat(qs.isEmpty()).isFalse();
 
-    assertTrue(qs.contains("limit"));
-    assertTrue(qs.contains("offset"));
-    assertTrue(qs.contains("status"));
-    assertFalse(qs.contains("sort"));
-    assertFalse(qs.contains("startDate"));
+    assertThat(qs.contains("limit")).isTrue();
+    assertThat(qs.contains("offset")).isTrue();
+    assertThat(qs.contains("status")).isTrue();
+    assertThat(qs.contains("sort")).isFalse();
+    assertThat(qs.contains("startDate")).isFalse();
   }
 
   @Test
@@ -60,22 +59,22 @@ final class ApplicationFilterFilterFormTest {
 
     String qs = filterForm.toString();
 
-    assertFalse(qs.isEmpty());
+    assertThat(qs.isEmpty()).isFalse();
 
-    assertTrue(qs.contains("filterAppCode"));
-    assertTrue(qs.contains("filterCompliance"));
-    assertTrue(qs.contains("filterLanguages"));
-    assertTrue(qs.contains("filterServers"));
-    assertTrue(qs.contains("filterTags"));
-    assertTrue(qs.contains("filterTechs"));
-    assertTrue(qs.contains("filterText"));
-    assertTrue(qs.contains("filterVulnSeverities"));
-    assertTrue(qs.contains("environment"));
-    assertTrue(qs.contains("quickFilter"));
+    assertThat(qs.contains("filterAppCode")).isTrue();
+    assertThat(qs.contains("filterCompliance")).isTrue();
+    assertThat(qs.contains("filterLanguages")).isTrue();
+    assertThat(qs.contains("filterServers")).isTrue();
+    assertThat(qs.contains("filterTags")).isTrue();
+    assertThat(qs.contains("filterTechs")).isTrue();
+    assertThat(qs.contains("filterText")).isTrue();
+    assertThat(qs.contains("filterVulnSeverities")).isTrue();
+    assertThat(qs.contains("environment")).isTrue();
+    assertThat(qs.contains("quickFilter")).isTrue();
 
-    assertTrue(qs.contains("includeArchived"));
-    assertTrue(qs.contains("includeMerged"));
-    assertTrue(qs.contains("includeOnlyLicensed"));
+    assertThat(qs.contains("includeArchived")).isTrue();
+    assertThat(qs.contains("includeMerged")).isTrue();
+    assertThat(qs.contains("includeOnlyLicensed")).isTrue();
   }
 
   @Test
@@ -88,16 +87,16 @@ final class ApplicationFilterFilterFormTest {
 
     String qs = filterForm.toString();
 
-    assertFalse(qs.isEmpty());
+    assertThat(qs.isEmpty()).isFalse();
 
-    assertTrue(qs.contains("expand"));
+    assertThat(qs.contains("expand")).isTrue();
 
     String expandValues = qs.split("=")[1];
     ArrayList<String> values = new ArrayList<>(Arrays.asList(expandValues.split(",")));
 
-    assertTrue(values.contains("scores"));
-    assertFalse(values.contains("apps"));
-    assertFalse(values.contains("test"));
-    assertFalse(values.contains("libs"));
+    assertThat(values.contains("scores")).isTrue();
+    assertThat(values.contains("apps")).isFalse();
+    assertThat(values.contains("test")).isFalse();
+    assertThat(values.contains("libs")).isFalse();
   }
 }

--- a/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/ApplicationFilterFilterFormTest.java
@@ -1,7 +1,7 @@
 package com.contrastsecurity;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.contrastsecurity.http.ApplicationFilterForm;
 import com.contrastsecurity.http.FilterForm;
@@ -10,14 +10,14 @@ import com.contrastsecurity.http.ServerEnvironment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ApplicationFilterFilterFormTest {
+final class ApplicationFilterFilterFormTest {
 
   ApplicationFilterForm filterForm;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     filterForm = new ApplicationFilterForm();
   }

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -1,6 +1,11 @@
 package com.contrastsecurity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.contrastsecurity.exceptions.InvalidConversionException;
 import com.contrastsecurity.exceptions.ResourceNotFoundException;
@@ -10,7 +15,23 @@ import com.contrastsecurity.http.IntegrationName;
 import com.contrastsecurity.http.JobOutcomePolicyListResponse;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.SecurityCheckResponse;
-import com.contrastsecurity.models.*;
+import com.contrastsecurity.models.Applications;
+import com.contrastsecurity.models.Chapter;
+import com.contrastsecurity.models.EventResource;
+import com.contrastsecurity.models.EventSummaryResponse;
+import com.contrastsecurity.models.HttpRequestResponse;
+import com.contrastsecurity.models.JobOutcomePolicy;
+import com.contrastsecurity.models.MetadataEntity;
+import com.contrastsecurity.models.RecommendationResponse;
+import com.contrastsecurity.models.Rules;
+import com.contrastsecurity.models.SecurityCheck;
+import com.contrastsecurity.models.Servers;
+import com.contrastsecurity.models.Story;
+import com.contrastsecurity.models.StoryResponse;
+import com.contrastsecurity.models.Tags;
+import com.contrastsecurity.models.TagsResponse;
+import com.contrastsecurity.models.Traces;
+import com.contrastsecurity.models.VulnerabilityTrend;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.contrastsecurity.utils.ContrastSDKUtils;
 import com.contrastsecurity.utils.MetadataDeserializer;
@@ -19,16 +40,15 @@ import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.net.URLConnection;
 import java.util.List;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class ContrastSDKTest extends ContrastSDK {
+final class ContrastSDKTest extends ContrastSDK {
 
   private static ContrastSDK contrastSDK;
   private static Gson gson;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     contrastSDK =
         new ContrastSDK.Builder("test_user", "testApiKey", "testServiceKey")
@@ -107,18 +127,12 @@ public class ContrastSDKTest extends ContrastSDK {
 
     assertNotNull(metadataEntities[0]);
     assertEquals(metadataEntities[0].getType(), MetadataEntity.MetadataType.POINT_OF_CONTACT);
-    assertThat(
-        metadataEntities[0].getAsPointOfContactMetadata(),
-        new IsInstanceOf(PointOfContactMetadata.class));
 
     assertNotNull(metadataEntities[1]);
     assertEquals(metadataEntities[1].getType(), MetadataEntity.MetadataType.STRING);
-    assertThat(
-        metadataEntities[1].getAsFreeformMetadata(), new IsInstanceOf(FreeformMetadata.class));
 
     assertNotNull(metadataEntities[2]);
     assertEquals(metadataEntities[2].getType(), MetadataEntity.MetadataType.NUMERIC);
-    assertThat(metadataEntities[2].getAsNumericMetadata(), new IsInstanceOf(NumericMetadata.class));
   }
 
   @Test

--- a/src/test/java/com/contrastsecurity/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/ContrastSDKTest.java
@@ -1,11 +1,6 @@
 package com.contrastsecurity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrastsecurity.exceptions.InvalidConversionException;
 import com.contrastsecurity.exceptions.ResourceNotFoundException;
@@ -70,10 +65,10 @@ final class ContrastSDKTest extends ContrastSDK {
         "{\"application\":{\"app_id\":\"3da856f4-c508-48b8-95a9-514eddefcbf3\",\"archived\":false,\"created\":1461599820000,\"status\":\"offline\",\"path\":\"/WebGoat\",\"name\":\"WebGoat\",\"language\":\"Java\",\"last_seen\":1461737160000,\"total_modules\":1,\"master\":false}}";
 
     Applications app = gson.fromJson(applicationString, Applications.class);
-    assertNotNull(app);
-    assertNotNull(app.getApplication());
+    assertThat(app).isNotNull();
+    assertThat(app.getApplication()).isNotNull();
 
-    assertNull(app.getApplications());
+    assertThat(app.getApplications()).isNull();
   }
 
   @Test
@@ -85,11 +80,11 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Applications apps = gson.fromJson(applicationsString, Applications.class);
 
-    assertNotNull(apps);
-    assertNotNull(apps.getApplications());
+    assertThat(apps).isNotNull();
+    assertThat(apps.getApplications()).isNotNull();
 
-    assertNull(apps.getApplication());
-    assertTrue(!apps.getApplications().isEmpty());
+    assertThat(apps.getApplication()).isNull();
+    assertThat(!apps.getApplications().isEmpty()).isTrue();
   }
 
   @Test
@@ -101,11 +96,11 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Applications apps = gson.fromJson(applicationsString, Applications.class);
 
-    assertNotNull(apps);
-    assertNotNull(apps.getApplications());
+    assertThat(apps).isNotNull();
+    assertThat(apps.getApplications()).isNotNull();
 
-    assertNull(apps.getApplication());
-    assertTrue(!apps.getApplications().isEmpty());
+    assertThat(apps.getApplication()).isNull();
+    assertThat(!apps.getApplications().isEmpty()).isTrue();
   }
 
   @Test
@@ -118,21 +113,22 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Applications apps = gson.fromJson(applicationsString, Applications.class);
 
-    assertNotNull(apps);
-    assertNotNull(apps.getApplications());
+    assertThat(apps).isNotNull();
+    assertThat(apps.getApplications()).isNotNull();
 
-    assertNotNull(apps.getApplications().get(0).getMetadataEntities());
+    assertThat(apps.getApplications().get(0).getMetadataEntities()).isNotNull();
     MetadataEntity[] metadataEntities = apps.getApplications().get(0).getMetadataEntities();
-    assertEquals(3, apps.getApplications().get(0).getMetadataEntities().length);
+    assertThat(apps.getApplications().get(0).getMetadataEntities().length).isEqualTo(3);
 
-    assertNotNull(metadataEntities[0]);
-    assertEquals(metadataEntities[0].getType(), MetadataEntity.MetadataType.POINT_OF_CONTACT);
+    assertThat(metadataEntities[0]).isNotNull();
+    assertThat(MetadataEntity.MetadataType.POINT_OF_CONTACT)
+        .isEqualTo(metadataEntities[0].getType());
 
-    assertNotNull(metadataEntities[1]);
-    assertEquals(metadataEntities[1].getType(), MetadataEntity.MetadataType.STRING);
+    assertThat(metadataEntities[1]).isNotNull();
+    assertThat(MetadataEntity.MetadataType.STRING).isEqualTo(metadataEntities[1].getType());
 
-    assertNotNull(metadataEntities[2]);
-    assertEquals(metadataEntities[2].getType(), MetadataEntity.MetadataType.NUMERIC);
+    assertThat(metadataEntities[2]).isNotNull();
+    assertThat(MetadataEntity.MetadataType.NUMERIC).isEqualTo(metadataEntities[2].getType());
   }
 
   @Test
@@ -143,10 +139,10 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Traces traces = gson.fromJson(tracesString, Traces.class);
 
-    assertNotNull(traces);
-    assertNotNull(traces.getTraces());
+    assertThat(traces).isNotNull();
+    assertThat(traces.getTraces()).isNotNull();
 
-    assertTrue(traces.getCount() > 0);
+    assertThat(traces.getCount() > 0).isTrue();
   }
 
   @Test
@@ -157,8 +153,8 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Rules rules = gson.fromJson(rulesString, Rules.class);
 
-    assertNotNull(rules);
-    assertNotNull(rules.getRules());
+    assertThat(rules).isNotNull();
+    assertThat(rules.getRules()).isNotNull();
   }
 
   @Test
@@ -169,8 +165,8 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Servers servers = gson.fromJson(serversString, Servers.class);
 
-    assertNotNull(servers);
-    assertNotNull(servers.getServers());
+    assertThat(servers).isNotNull();
+    assertThat(servers.getServers()).isNotNull();
   }
 
   @Test
@@ -182,12 +178,12 @@ final class ContrastSDKTest extends ContrastSDK {
         gson.fromJson(securityCheckResponseString, SecurityCheckResponse.class);
     SecurityCheck securityCheck = response.getSecurityCheck();
     JobOutcomePolicy jobOutcomePolicy = securityCheck.getJobOutcomePolicy();
-    assertEquals(1l, securityCheck.getId().longValue());
-    assertEquals("testName", securityCheck.getApplicationName());
-    assertEquals("testPolicy", jobOutcomePolicy.getName());
-    assertEquals(JobOutcomePolicy.Outcome.UNSTABLE, jobOutcomePolicy.getOutcome());
-    assertEquals(1, jobOutcomePolicy.getSeverities().size());
-    assertEquals(1l, jobOutcomePolicy.getSeverities().get(RuleSeverity.MEDIUM).longValue());
+    assertThat(securityCheck.getId().longValue()).isEqualTo(1l);
+    assertThat(securityCheck.getApplicationName()).isEqualTo("testName");
+    assertThat(jobOutcomePolicy.getName()).isEqualTo("testPolicy");
+    assertThat(jobOutcomePolicy.getOutcome()).isEqualTo(JobOutcomePolicy.Outcome.UNSTABLE);
+    assertThat(jobOutcomePolicy.getSeverities().size()).isEqualTo(1);
+    assertThat(jobOutcomePolicy.getSeverities().get(RuleSeverity.MEDIUM).longValue()).isEqualTo(1l);
   }
 
   @Test
@@ -196,8 +192,8 @@ final class ContrastSDKTest extends ContrastSDK {
         "{'policies':[{'name':'testJobOutcomePolicy','outcome':'SUCCESS'}]}";
     JobOutcomePolicyListResponse response =
         gson.fromJson(jobOutcomePolicyListResponseString, JobOutcomePolicyListResponse.class);
-    assertNotNull(response.getPolicies());
-    assertEquals(response.getPolicies().get(0).getName(), "testJobOutcomePolicy");
+    assertThat(response.getPolicies()).isNotNull();
+    assertThat("testJobOutcomePolicy").isEqualTo(response.getPolicies().get(0).getName());
   }
 
   @Test
@@ -206,8 +202,8 @@ final class ContrastSDKTest extends ContrastSDK {
         "{'policies':[{'name':'testJobOutcomePolicy','outcome':'UNSTABLE'}]}";
     JobOutcomePolicyListResponse response =
         gson.fromJson(jobOutcomePolicyListResponseString, JobOutcomePolicyListResponse.class);
-    assertNotNull(response.getPolicies());
-    assertEquals(response.getPolicies().get(0).getName(), "testJobOutcomePolicy");
+    assertThat(response.getPolicies()).isNotNull();
+    assertThat("testJobOutcomePolicy").isEqualTo(response.getPolicies().get(0).getName());
   }
 
   @Test
@@ -220,8 +216,8 @@ final class ContrastSDKTest extends ContrastSDK {
     URLConnection conn =
         contrastSDK.makeConnection("https://www.google.com", HttpMethod.GET.toString());
 
-    assertEquals(connectionTimeout, conn.getConnectTimeout());
-    assertEquals(readTimeout, conn.getReadTimeout());
+    assertThat(conn.getConnectTimeout()).isEqualTo(connectionTimeout);
+    assertThat(conn.getReadTimeout()).isEqualTo(readTimeout);
   }
 
   @Test
@@ -235,8 +231,8 @@ final class ContrastSDKTest extends ContrastSDK {
     URLConnection conn =
         contrastSDK.makeConnection("https://www.google.com", HttpMethod.GET.toString());
 
-    assertNotEquals(connectionTimeout, conn.getConnectTimeout());
-    assertNotEquals(readTimeout, conn.getReadTimeout());
+    assertThat(conn.getConnectTimeout()).isNotEqualTo(connectionTimeout);
+    assertThat(conn.getReadTimeout()).isNotEqualTo(readTimeout);
   }
 
   @Test
@@ -245,13 +241,13 @@ final class ContrastSDKTest extends ContrastSDK {
     final String ensureUrlOne = ContrastSDKUtils.ensureApi("http://localhost:19080/Contrast/");
     final String ensureUrlTwo = ContrastSDKUtils.ensureApi("http://localhost:19080/Contrast");
 
-    assertEquals(expectedApi, ensureUrlOne);
-    assertEquals(expectedApi, ensureUrlTwo);
+    assertThat(ensureUrlOne).isEqualTo(expectedApi);
+    assertThat(ensureUrlTwo).isEqualTo(expectedApi);
 
     final String unchangedApi = "http://localhost:19080/";
     final String ensureUnchanged = ContrastSDKUtils.ensureApi(unchangedApi);
 
-    assertEquals(unchangedApi, ensureUnchanged);
+    assertThat(ensureUnchanged).isEqualTo(unchangedApi);
   }
 
   @Test
@@ -259,20 +255,20 @@ final class ContrastSDKTest extends ContrastSDK {
     final String expectedUrl = "htp:/localhost:19080/Contrast/api";
     final String badUrl = "htp:/localhost:19080/Contrast/";
     final String actualUrl = ContrastSDKUtils.ensureApi(badUrl);
-    assertEquals(actualUrl, expectedUrl);
+    assertThat(expectedUrl).isEqualTo(actualUrl);
   }
 
   @Test
   public void testNullUrl() throws IOException {
     final String nullUrl = ContrastSDKUtils.ensureApi(null);
-    assertNull(nullUrl);
+    assertThat(nullUrl).isNull();
   }
 
   @Test
   public void blankUrl() {
     final String blankUrl = ContrastSDKUtils.ensureApi("");
     final String ensureBlank = "";
-    assertEquals(ensureBlank, blankUrl);
+    assertThat(blankUrl).isEqualTo(ensureBlank);
   }
 
   @Test
@@ -281,9 +277,9 @@ final class ContrastSDKTest extends ContrastSDK {
         "{  \"success\": true,  \"messages\": [    \"Total Vulnerability trend loaded successfully\"  ],  \"open\": [    {      \"timestamp\": 1567310400000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1569902400000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1572580800000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1575176400000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1577854800000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1580533200000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1583038800000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1585713600000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1588305600000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 0        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1590984000000,      \"count\": 9,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 9        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1593576000000,      \"count\": 8,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 8        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1596254400000,      \"count\": 8,      \"statusBreakdown\": [        {          \"name\": \"Reported\",          \"value\": 8        },        {          \"name\": \"Suspicious\",          \"value\": 0        },        {          \"name\": \"Confirmed\",          \"value\": 0        }      ]    }  ],  \"closed\": [    {      \"timestamp\": 1567310400000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1569902400000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1572580800000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1575176400000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1577854800000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1580533200000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1583038800000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1585713600000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1588305600000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1590984000000,      \"count\": 0,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 0        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1593576000000,      \"count\": 1,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 1        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    },    {      \"timestamp\": 1596254400000,      \"count\": 1,      \"statusBreakdown\": [        {          \"name\": \"NotAProblem\",          \"value\": 1        },        {          \"name\": \"Remediated\",          \"value\": 0        },        {          \"name\": \"Fixed\",          \"value\": 0        },        {          \"name\": \"AutoRemediated\",          \"value\": 0        }      ]    }  ]}";
     VulnerabilityTrend vulnerabilityTrend =
         gson.fromJson(exampleApplicationYearlyTrend, VulnerabilityTrend.class);
-    assertNotNull(vulnerabilityTrend);
-    assertNotNull(vulnerabilityTrend.getOpenTrend());
-    assertNotNull(vulnerabilityTrend.getClosedTrend());
+    assertThat(vulnerabilityTrend).isNotNull();
+    assertThat(vulnerabilityTrend.getOpenTrend()).isNotNull();
+    assertThat(vulnerabilityTrend.getClosedTrend()).isNotNull();
   }
 
   @Test
@@ -292,15 +288,18 @@ final class ContrastSDKTest extends ContrastSDK {
         "{ \"success\" : true, \"messages\" : [ \"Vulnerability recommendation loaded successfully\" ], \"recommendation\" : { \"text\" : \"test recommendation\", \"formattedTextVariables\" : { } }, \"owasp\" : \"OWASP link\", \"cwe\" : \"CWE link\", \"custom_recommendation\" : { \"text\" : \"custom recommendation\", \"formattedText\" : \"custom recommendation\", \"formattedTextVariables\" : { } }, \"rule_references\" : { \"text\" : \"rule reference\", \"formattedText\" : \"rule reference\", \"formattedTextVariables\" : { } }, \"custom_rule_references\" : { \"text\" : \"test custom\", \"formattedText\" : \"test custom\", \"formattedTextVariables\" : { } } }";
     RecommendationResponse vulnerabilityRecommendation =
         gson.fromJson(recommendation, RecommendationResponse.class);
-    assertNotNull(vulnerabilityRecommendation);
+    assertThat(vulnerabilityRecommendation).isNotNull();
 
-    assertEquals(vulnerabilityRecommendation.getRecommendation().getText(), "test recommendation");
-    assertEquals(
-        vulnerabilityRecommendation.getCustomRecommendation().getText(), "custom recommendation");
-    assertEquals(vulnerabilityRecommendation.getCustomRuleReferences().getText(), "test custom");
-    assertEquals(vulnerabilityRecommendation.getCwe(), "CWE link");
-    assertEquals(vulnerabilityRecommendation.getOwasp(), "OWASP link");
-    assertEquals(vulnerabilityRecommendation.getRuleReferences().getText(), "rule reference");
+    assertThat("test recommendation")
+        .isEqualTo(vulnerabilityRecommendation.getRecommendation().getText());
+    assertThat("custom recommendation")
+        .isEqualTo(vulnerabilityRecommendation.getCustomRecommendation().getText());
+    assertThat("test custom")
+        .isEqualTo(vulnerabilityRecommendation.getCustomRuleReferences().getText());
+    assertThat("CWE link").isEqualTo(vulnerabilityRecommendation.getCwe());
+    assertThat("OWASP link").isEqualTo(vulnerabilityRecommendation.getOwasp());
+    assertThat("rule reference")
+        .isEqualTo(vulnerabilityRecommendation.getRuleReferences().getText());
   }
 
   @Test
@@ -309,15 +308,15 @@ final class ContrastSDKTest extends ContrastSDK {
         "{ \"success\" : true, \"messages\" : [ \"Vulnerability story loaded successfully\" ], \"story\" : { \"traceId\" : \"testID\", \"chapters\" : [ { \"type\" : \"source\", \"introText\" : \"test intro\", \"introTextFormat\" : \"test intro formatted\", \"introTextVariables\" : { \"source0\" : \"\\Test variable 1\" }, \"body\" : \"test body 1\", \"bodyFormat\" : \"test body formatted\", \"bodyFormatVariables\" : { \"paramNameKey1\" : \"test param 1\", \"paramValueKey1\" : \"test param 2\", \"urlVariableKey\" : \"test param 3\" } }, { \"type\" : \"location\", \"introText\" : \"intro text 2\", \"introTextFormat\" : \"intro text 2 formatted\", \"introTextVariables\" : { }, \"body\" : \"test body 2\", \"bodyFormat\" : \"test body 2 formatted\", \"bodyFormatVariables\" : { \"line\" : \"test line number\", \"methodName\" : \"test method name\", \"className\" : \"test class name\" } }, { \"type\" : \"dataflow\", \"introText\" : \"test chapter intro text\", \"introTextFormat\" : \"test chapter intro text formatted\", \"introTextVariables\" : { }, \"body\" : \"test body 3\", \"bodyFormat\" : \"test body 3 formatted\", \"bodyFormatVariables\" : { \"untrustedTaintedKey0\" : \"variable 3\" }, \"vector\" : null } ], \"risk\" : { \"text\" : \"test risk\", \"formattedTextVariables\" : { } } }, \"custom_risk\" : { \"test custom risk\" : \"\", \"formattedText\" : \"\", \"formattedTextVariables\" : { } } }";
     StoryResponse storyResponse = gson.fromJson(storyString, StoryResponse.class);
     Story story = storyResponse.getStory();
-    assertNotNull(story);
+    assertThat(story).isNotNull();
 
     List<Chapter> chapters = story.getChapters();
 
-    assertFalse(chapters.isEmpty());
+    assertThat(chapters.isEmpty()).isFalse();
     chapters.forEach(
         chapter -> {
           int index = Integer.parseInt(String.valueOf(chapters.indexOf(chapter))) + 1;
-          assertEquals(chapter.getBody(), "test body " + index);
+          assertThat("test body " + index).isEqualTo(chapter.getBody());
         });
   }
 
@@ -327,11 +326,11 @@ final class ContrastSDKTest extends ContrastSDK {
         "{ \"success\" : true, \"messages\" : [ \"Tags for vulnerability loaded successfully\" ], \"tags\" : [ \"tag1\", \"tag2\", \"tag3\", \"tag4\" ] }";
     TagsResponse tags = gson.fromJson(tagsString, TagsResponse.class);
 
-    assertFalse(tags.getTags().isEmpty());
+    assertThat(tags.getTags().isEmpty()).isFalse();
 
     Tags tagsObject = new Tags(tags.getTags());
 
-    assertFalse(tagsObject.getTags().isEmpty());
+    assertThat(tagsObject.getTags().isEmpty()).isFalse();
   }
 
   @Test
@@ -340,9 +339,9 @@ final class ContrastSDKTest extends ContrastSDK {
         "{ \"success\" : true, \"messages\" : [ \"Vulnerability HTTP Request loaded successfully\" ], \"http_request\" : { \"text\" : \"test request method\", \"formattedText\" : \"test request method formatted\", \"formattedTextVariables\" : { \"headerNameKey6\" : \"Host\"  } } }";
     HttpRequestResponse http = gson.fromJson(httpRequest, HttpRequestResponse.class);
 
-    assertNotNull(http.getHttpRequest());
+    assertThat(http.getHttpRequest()).isNotNull();
 
-    assertEquals(http.getHttpRequest().getText(), "test request method");
+    assertThat("test request method").isEqualTo(http.getHttpRequest().getText());
   }
 
   @Test
@@ -350,15 +349,15 @@ final class ContrastSDKTest extends ContrastSDK {
     final String eventString =
         "{\"success\" : true,\"messages\" : [ \"Vulnerability events summary loaded successfully\" ], \"risk\" : \"test risk\", \"showEvidence\" : false,\"showEvents\" : true,\"events\" : [ { \"id\" : \"612\", \"important\" : true,\"type\" : \"Creation\",\"description\" : \"Test description 1\",\"extraDetails\" : null, \"codeView\" : { \"lines\" : [ {\"fragments\" : [ { \"type\" : \"NORMAL_CODE\", \"value\" : \"code\" }, {\"type\" : \"CODE_STRING\",\"value\" : \"code\"}, {\"type\" : \"NORMAL_CODE\",\"value\" : \"code\"} ],\"text\" : \"code\" } ],\"nested\" : false},\"probableStartLocationView\" : { \"lines\" : [ { \"fragments\" : [ {\"type\" : \"STACKTRACE_LINE\",\"value\" : \"code\"} ],\"text\" : \"code\"} ],\"nested\" : false},\"dataView\" : {\"lines\" : [ {\"fragments\" : [ { \"type\" : \"TEXT\", \"value\" : \"code\" }, {\"type\" : \"TAINT_VALUE\",\"value\" : \"code\"} ], \"text\" : \"code\"} ],\"nested\" : false},\"collapsedEvents\" : [ ], \"dupes\" : 0}, { \"id\" : \"613\",\"important\" : true,\"type\" : \"Trigger\",\"description\" : \"Test description 2\",\"extraDetails\" : null,\"codeView\" : {\"lines\" : [ {\"fragments\" : [ { \"type\" : \"NORMAL_CODE\",\"value\" : \"code\"}, {\"type\" : \"CODE_STRING\",\"value\" : \"code\"}, {\"type\" : \"NORMAL_CODE\",\"value\" : \")\"} ],\"text\" : \"code\"} ],\"nested\" : false},\"probableStartLocationView\" : {\"lines\" : [ { \"fragments\" : [ {\"type\" : \"STACKTRACE_LINE\",\"value\" : \"code\"} ],\"text\" : \"code\"} ],\"nested\" : false},\"dataView\" : { \"lines\" : [ {\"fragments\" : [ {\"type\" : \"TAINT_VALUE\",\"value\" : \"code\"} ],\"text\" : \"code\"} ], \"nested\" : false}, \"collapsedEvents\" : [ ], \"dupes\" : 0} ]}";
     EventSummaryResponse event = gson.fromJson(eventString, EventSummaryResponse.class);
-    assertNotNull(event);
+    assertThat(event).isNotNull();
 
     List<EventResource> eventResources = event.getEvents();
-    assertFalse(eventResources.isEmpty());
+    assertThat(eventResources.isEmpty()).isFalse();
 
-    assertEquals(event.getRisk(), "test risk");
+    assertThat("test risk").isEqualTo(event.getRisk());
 
-    assertTrue(event.getShowEvents());
-    assertFalse(event.getShowEvidence());
+    assertThat(event.getShowEvents()).isTrue();
+    assertThat(event.getShowEvidence()).isFalse();
   }
 
   @Test
@@ -369,9 +368,9 @@ final class ContrastSDKTest extends ContrastSDK {
 
     Traces traces = gson.fromJson(traceMetadataString, Traces.class);
 
-    assertNotNull(traces);
-    assertNotNull(traces.getTraces());
+    assertThat(traces).isNotNull();
+    assertThat(traces.getTraces()).isNotNull();
 
-    assertTrue(traces.getCount() > 0);
+    assertThat(traces.getCount() > 0).isTrue();
   }
 }

--- a/src/test/java/com/contrastsecurity/FilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/FilterFormTest.java
@@ -1,7 +1,6 @@
 package com.contrastsecurity;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrastsecurity.http.FilterForm;
 import java.util.ArrayList;
@@ -27,16 +26,16 @@ final class FilterFormTest {
 
     String qs = filterForm.toString();
 
-    assertFalse(qs.isEmpty());
+    assertThat(qs.isEmpty()).isFalse();
 
-    assertTrue(qs.contains("limit"));
-    assertTrue(qs.contains("offset"));
-    assertTrue(qs.contains("status"));
-    assertFalse(qs.contains("sort"));
-    assertFalse(qs.contains("startDate"));
+    assertThat(qs.contains("limit")).isTrue();
+    assertThat(qs.contains("offset")).isTrue();
+    assertThat(qs.contains("status")).isTrue();
+    assertThat(qs.contains("sort")).isFalse();
+    assertThat(qs.contains("startDate")).isFalse();
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testExpand() {
     EnumSet<FilterForm.ApplicationExpandValues> expand =
         EnumSet.of(
@@ -46,18 +45,18 @@ final class FilterFormTest {
 
     String qs = filterForm.toString();
 
-    assertFalse(qs.isEmpty());
+    assertThat(qs.isEmpty()).isFalse();
 
-    assertTrue(qs.contains("expand"));
+    assertThat(qs.contains("expand")).isTrue();
 
     String expandValues = qs.split("=")[1];
     ArrayList<String> values = new ArrayList<>(Arrays.asList(expandValues.split(",")));
 
-    assertTrue(values.contains("scores"));
-    assertTrue(values.contains("license"));
+    assertThat(values.contains("scores")).isTrue();
+    assertThat(values.contains("license")).isTrue();
 
-    assertFalse(values.contains("apps"));
-    assertFalse(values.contains("test"));
-    assertFalse(values.contains("libs"));
+    assertThat(values.contains("apps")).isFalse();
+    assertThat(values.contains("test")).isFalse();
+    assertThat(values.contains("libs")).isFalse();
   }
 }

--- a/src/test/java/com/contrastsecurity/FilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/FilterFormTest.java
@@ -1,20 +1,20 @@
 package com.contrastsecurity;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.contrastsecurity.http.FilterForm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class FilterFormTest {
+final class FilterFormTest {
 
   FilterForm filterForm;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     filterForm = new FilterForm();
   }
@@ -36,7 +36,7 @@ public class FilterFormTest {
     assertFalse(qs.contains("startDate"));
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testExpand() {
     EnumSet<FilterForm.ApplicationExpandValues> expand =
         EnumSet.of(

--- a/src/test/java/com/contrastsecurity/ScreenerTest.java
+++ b/src/test/java/com/contrastsecurity/ScreenerTest.java
@@ -1,6 +1,8 @@
 package com.contrastsecurity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.ApplicationFilterForm;
@@ -15,16 +17,16 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class ScreenerTest {
+final class ScreenerTest {
 
   private static ContrastSDK contrastSDK;
   private static final String TEST_PROPERTIES = "test.properties";
   private static Properties properties;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws IOException {
     InputStream propertiesFileInputStream =
         Thread.currentThread().getContextClassLoader().getResourceAsStream(TEST_PROPERTIES);
@@ -40,7 +42,7 @@ public class ScreenerTest {
             .build();
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testDownloadAgent() throws IOException {
     File contrastJar = new File("contrast.jar");
 
@@ -62,14 +64,14 @@ public class ScreenerTest {
     assertTrue(!organizations.getOrganizations().isEmpty());
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testGetProfileDefaultOrganization() throws IOException, UnauthorizedException {
     Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
 
     assertTrue(organizations.getOrganization().getName() != null);
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testGetApplications() throws IOException, UnauthorizedException {
     String orgId = properties.getProperty("orgId");
 
@@ -78,7 +80,7 @@ public class ScreenerTest {
     assertTrue(!applications.getApplications().isEmpty());
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testGetServers() throws IOException, UnauthorizedException {
     String orgId = properties.getProperty("orgId");
 

--- a/src/test/java/com/contrastsecurity/ScreenerTest.java
+++ b/src/test/java/com/contrastsecurity/ScreenerTest.java
@@ -1,8 +1,6 @@
 package com.contrastsecurity;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.ApplicationFilterForm;
@@ -42,7 +40,7 @@ final class ScreenerTest {
             .build();
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testDownloadAgent() throws IOException {
     File contrastJar = new File("contrast.jar");
 
@@ -50,43 +48,43 @@ final class ScreenerTest {
       FileUtils.writeByteArrayToFile(
           contrastJar, contrastSDK.getAgent(AgentType.JAVA, properties.getProperty("orgId")));
     } catch (IOException | UnauthorizedException e) {
-      assertTrue(true);
+      assertThat(true).isTrue();
     }
 
-    assertTrue(contrastJar.exists());
-    assertTrue(FileUtils.sizeOf(contrastJar) > 0);
+    assertThat(contrastJar.exists()).isTrue();
+    assertThat(FileUtils.sizeOf(contrastJar) > 0).isTrue();
   }
 
   @Test
   public void testGetProfileOrganizations() throws IOException, UnauthorizedException {
     Organizations organizations = contrastSDK.getProfileOrganizations();
 
-    assertTrue(!organizations.getOrganizations().isEmpty());
+    assertThat(!organizations.getOrganizations().isEmpty()).isTrue();
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testGetProfileDefaultOrganization() throws IOException, UnauthorizedException {
     Organizations organizations = contrastSDK.getProfileDefaultOrganizations();
 
-    assertTrue(organizations.getOrganization().getName() != null);
+    assertThat(organizations.getOrganization().getName() != null).isTrue();
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testGetApplications() throws IOException, UnauthorizedException {
     String orgId = properties.getProperty("orgId");
 
     Applications applications = contrastSDK.getApplications(orgId);
 
-    assertTrue(!applications.getApplications().isEmpty());
+    assertThat(!applications.getApplications().isEmpty()).isTrue();
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testGetServers() throws IOException, UnauthorizedException {
     String orgId = properties.getProperty("orgId");
 
     Servers servers = contrastSDK.getServers(orgId, null);
 
-    assertTrue(!servers.getServers().isEmpty());
+    assertThat(!servers.getServers().isEmpty()).isTrue();
   }
 
   @Test
@@ -95,11 +93,11 @@ final class ScreenerTest {
 
     Applications applications = contrastSDK.getApplications(orgId);
 
-    assertTrue(!applications.getApplications().isEmpty());
+    assertThat(!applications.getApplications().isEmpty()).isTrue();
 
     Application application = applications.getApplications().get(0);
 
-    assertTrue(application.getId() != null);
+    assertThat(application.getId() != null).isTrue();
 
     TraceFilterForm form = new TraceFilterForm();
 
@@ -107,7 +105,7 @@ final class ScreenerTest {
 
     Traces traces = contrastSDK.getTraces(orgId, application.getId(), form);
 
-    assertTrue(!traces.getTraces().isEmpty());
+    assertThat(!traces.getTraces().isEmpty()).isTrue();
   }
 
   @Test
@@ -118,11 +116,11 @@ final class ScreenerTest {
 
     Applications applications = contrastSDK.getFilteredApplications(orgId, form);
 
-    assertFalse(applications.getApplications().isEmpty());
+    assertThat(applications.getApplications().isEmpty()).isFalse();
 
     Application application = applications.getApplications().get(0);
 
-    assertNotNull(application.getId());
+    assertThat(application.getId()).isNotNull();
 
     List<String> languages = new ArrayList<>();
     languages.add("Java");
@@ -135,6 +133,6 @@ final class ScreenerTest {
 
     Applications licensedApplications = contrastSDK.getFilteredApplications(orgId, form);
 
-    assertFalse(licensedApplications.getApplications().isEmpty());
+    assertThat(licensedApplications.getApplications().isEmpty()).isFalse();
   }
 }

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -1,7 +1,7 @@
 package com.contrastsecurity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.contrastsecurity.http.ApplicationFilterForm;
 import com.contrastsecurity.http.TraceFilterForm;
@@ -11,17 +11,17 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class UrlBuilderTest {
+final class UrlBuilderTest {
 
   private static String applicationId;
   private static String organizationId;
   private static String testTrace;
   private static UrlBuilder urlBuilder;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     applicationId = "test-app";
     organizationId = "test-org";
@@ -77,7 +77,7 @@ public class UrlBuilderTest {
     assertEquals(expectedUrl, urlBuilder.getApplicationsUrl(organizationId));
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testApplicationsNamesUrl() {
     String expectedUrl = "/ng/test-org/applications/name";
 
@@ -187,7 +187,7 @@ public class UrlBuilderTest {
     assertEquals(expectedHttpUrl, urlBuilder.getHttpRequestByTraceId(organizationId, testTrace));
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testGetEventSummaryUrl() {
     String expectedEventSummaryUrl = "/ng/test-org/traces/test-trace/events/summary";
     assertEquals(expectedEventSummaryUrl, urlBuilder.getEventSummary(organizationId, testTrace));
@@ -219,7 +219,7 @@ public class UrlBuilderTest {
     assertEquals(expectedTagsUrl, urlBuilder.deleteTag(organizationId, testTrace));
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void testSetStatusUrl() {
     String expectedTagsUrl = "/ng/test-org/orgtraces/mark";
     assertEquals(expectedTagsUrl, urlBuilder.setTraceStatus(organizationId));

--- a/src/test/java/com/contrastsecurity/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/UrlBuilderTest.java
@@ -1,7 +1,6 @@
 package com.contrastsecurity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrastsecurity.http.ApplicationFilterForm;
 import com.contrastsecurity.http.TraceFilterForm;
@@ -34,14 +33,15 @@ final class UrlBuilderTest {
   public void testProfileOrganizationsUrl() {
     String expectedUrl = "/ng/profile/organizations";
 
-    assertEquals(expectedUrl, urlBuilder.getProfileOrganizationsUrl());
+    assertThat(urlBuilder.getProfileOrganizationsUrl()).isEqualTo(expectedUrl);
   }
 
   @Test
   public void testApplicationUrl() {
     String expectedUrl = "/ng/test-org/applications/test-app";
 
-    assertEquals(expectedUrl, urlBuilder.getApplicationUrl(organizationId, applicationId, null));
+    assertThat(urlBuilder.getApplicationUrl(organizationId, applicationId, null))
+        .isEqualTo(expectedUrl);
   }
 
   @Test
@@ -53,42 +53,42 @@ final class UrlBuilderTest {
 
     form.setExpand(EnumSet.of(ApplicationFilterForm.ApplicationExpandValues.LICENSE));
 
-    assertEquals(expectedUrl, urlBuilder.getApplicationFilterUrl(organizationId, form));
+    assertThat(urlBuilder.getApplicationFilterUrl(organizationId, form)).isEqualTo(expectedUrl);
   }
 
   @Test
   public void testCreateApplicationUrl() {
     String expectedUrl = "/ng/integrations/organizations/test-org/applications";
-    assertEquals(expectedUrl, urlBuilder.getCreateApplicationUrl(organizationId));
+    assertThat(urlBuilder.getCreateApplicationUrl(organizationId)).isEqualTo(expectedUrl);
   }
 
   @Test
   public void testApplicationByNameAndLanguageUrl() {
     String expectedUrl =
         "/ng/integrations/organizations/test-org/applications?name=app&language=JAVA";
-    assertEquals(
-        expectedUrl, urlBuilder.getApplicationByNameAndLanguageUrl(organizationId, "app", "JAVA"));
+    assertThat(urlBuilder.getApplicationByNameAndLanguageUrl(organizationId, "app", "JAVA"))
+        .isEqualTo(expectedUrl);
   }
 
   @Test
   public void testApplicationsUrl() {
     String expectedUrl = "/ng/test-org/applications?base=false";
 
-    assertEquals(expectedUrl, urlBuilder.getApplicationsUrl(organizationId));
+    assertThat(urlBuilder.getApplicationsUrl(organizationId)).isEqualTo(expectedUrl);
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testApplicationsNamesUrl() {
     String expectedUrl = "/ng/test-org/applications/name";
 
-    assertEquals(expectedUrl, urlBuilder.getApplicationsNameUrl(organizationId));
+    assertThat(urlBuilder.getApplicationsNameUrl(organizationId)).isEqualTo(expectedUrl);
   }
 
   @Test
   public void testCoverageUrl() {
     String expectedUrl = "/ng/test-org/applications/test-app/coverage";
 
-    assertEquals(expectedUrl, urlBuilder.getCoverageUrl(organizationId, applicationId));
+    assertThat(urlBuilder.getCoverageUrl(organizationId, applicationId)).isEqualTo(expectedUrl);
   }
 
   @Test
@@ -97,27 +97,23 @@ final class UrlBuilderTest {
 
     String resultUrl = urlBuilder.getLibrariesUrl(organizationId, applicationId, null);
 
-    assertEquals(expectedUrl, resultUrl);
+    assertThat(resultUrl).isEqualTo(expectedUrl);
   }
 
   @Test
-  public void testTracesUrl() {
+  public void testTracesUrl() throws UnsupportedEncodingException {
     String expectedUrl = "/ng/test-org/traces/test-app/filter/?expand=application";
 
     TraceFilterForm form = new TraceFilterForm();
 
     form.setExpand(EnumSet.of(TraceFilterForm.TraceExpandValue.APPLICATION));
 
-    try {
-      assertEquals(
-          expectedUrl, urlBuilder.getTracesByApplicationUrl(organizationId, applicationId, form));
-    } catch (UnsupportedEncodingException e) {
-      fail();
-    }
+    assertThat(urlBuilder.getTracesByApplicationUrl(organizationId, applicationId, form))
+        .isEqualTo(expectedUrl);
   }
 
   @Test
-  public void testGetTracesByApplicationUrl() {
+  public void testGetTracesByApplicationUrl() throws UnsupportedEncodingException {
     String expectedUrl = "/ng/test-org/traces/test-app/filter/?appVersionTags=The+application";
 
     TraceFilterForm form = new TraceFilterForm();
@@ -126,138 +122,130 @@ final class UrlBuilderTest {
 
     form.setAppVersionTags(appVersionTags);
 
-    try {
-      assertEquals(
-          expectedUrl, urlBuilder.getTracesByApplicationUrl(organizationId, applicationId, form));
-    } catch (UnsupportedEncodingException e) {
-      fail();
-    }
+    assertThat(urlBuilder.getTracesByApplicationUrl(organizationId, applicationId, form))
+        .isEqualTo(expectedUrl);
   }
 
   @Test
-  public void testGetTracesWithBodyUrl() {
+  public void testGetTracesWithBodyUrl() throws UnsupportedEncodingException {
     String expectedUrl = "/ng/test-org/traces/test-app/filter";
 
-    try {
-      assertEquals(expectedUrl, urlBuilder.getTracesWithBodyUrl(organizationId, applicationId));
-    } catch (UnsupportedEncodingException e) {
-      fail();
-    }
+    assertThat(urlBuilder.getTracesWithBodyUrl(organizationId, applicationId))
+        .isEqualTo(expectedUrl);
   }
 
   @Test
   public void testSecurityCheckUrl() {
     String expectedSecurityCheckUrl = "/ng/test-org/securityChecks";
-    assertEquals(expectedSecurityCheckUrl, urlBuilder.getSecurityCheckUrl(organizationId));
+    assertThat(urlBuilder.getSecurityCheckUrl(organizationId)).isEqualTo(expectedSecurityCheckUrl);
   }
 
   @Test
   public void testEnabledJobOutcomePolicyListUrl() {
     String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled";
-    assertEquals(
-        expectedJobOutcomePolicyListUrl,
-        urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId));
+    assertThat(urlBuilder.getEnabledJobOutcomePolicyListUrl(organizationId))
+        .isEqualTo(expectedJobOutcomePolicyListUrl);
   }
 
   @Test
   public void testEnabledJobOutcomePolicyListUrlByApplication() {
     String expectedJobOutcomePolicyListUrl = "/ng/test-org/jobOutcomePolicies/enabled/test-app";
-    assertEquals(
-        expectedJobOutcomePolicyListUrl,
-        urlBuilder.getEnabledJobOutcomePolicyListUrlByApplication(organizationId, applicationId));
+    assertThat(
+            urlBuilder.getEnabledJobOutcomePolicyListUrlByApplication(
+                organizationId, applicationId))
+        .isEqualTo(expectedJobOutcomePolicyListUrl);
   }
 
   @Test
   public void testGetRecommendationByTraceIdUrl() {
     String expectedRecommendationUrl = "/ng/test-org/traces/test-trace/recommendation";
-    assertEquals(
-        expectedRecommendationUrl,
-        urlBuilder.getRecommendationByTraceId(organizationId, testTrace));
+    assertThat(urlBuilder.getRecommendationByTraceId(organizationId, testTrace))
+        .isEqualTo(expectedRecommendationUrl);
   }
 
   @Test
   public void testGetStoryByTraceIdUrl() {
     String expectedStoryUrl = "/ng/test-org/traces/test-trace/story";
-    assertEquals(expectedStoryUrl, urlBuilder.getStoryByTraceId(organizationId, testTrace));
+    assertThat(urlBuilder.getStoryByTraceId(organizationId, testTrace)).isEqualTo(expectedStoryUrl);
   }
 
   @Test
   public void testGetHttpRequestByTraceIdUrl() {
     String expectedHttpUrl = "/ng/test-org/traces/test-trace/httprequest";
-    assertEquals(expectedHttpUrl, urlBuilder.getHttpRequestByTraceId(organizationId, testTrace));
+    assertThat(urlBuilder.getHttpRequestByTraceId(organizationId, testTrace))
+        .isEqualTo(expectedHttpUrl);
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testGetEventSummaryUrl() {
     String expectedEventSummaryUrl = "/ng/test-org/traces/test-trace/events/summary";
-    assertEquals(expectedEventSummaryUrl, urlBuilder.getEventSummary(organizationId, testTrace));
+    assertThat(urlBuilder.getEventSummary(organizationId, testTrace))
+        .isEqualTo(expectedEventSummaryUrl);
   }
 
   @Test
   public void testGetEventDetailsUrl() {
     String expectedEventDetailsUrl = "/ng/test-org/traces/test-trace/events/event-id/details";
-    assertEquals(
-        expectedEventDetailsUrl, urlBuilder.getEventDetails(organizationId, testTrace, "event-id"));
+    assertThat(urlBuilder.getEventDetails(organizationId, testTrace, "event-id"))
+        .isEqualTo(expectedEventDetailsUrl);
   }
 
   @Test
   public void testGetOrCreateTagsByOrganizationUrl() {
     String expectedGetOrCreateTagsUrl = "/ng/test-org/tags/traces";
-    assertEquals(
-        expectedGetOrCreateTagsUrl, urlBuilder.getOrCreateTagsByOrganization(organizationId));
+    assertThat(urlBuilder.getOrCreateTagsByOrganization(organizationId))
+        .isEqualTo(expectedGetOrCreateTagsUrl);
   }
 
   @Test
   public void testGetTagsByTraceUrl() {
     String expectedTagsUrl = "/ng/test-org/tags/traces/trace/test-trace";
-    assertEquals(expectedTagsUrl, urlBuilder.getTagsByTrace(organizationId, testTrace));
+    assertThat(urlBuilder.getTagsByTrace(organizationId, testTrace)).isEqualTo(expectedTagsUrl);
   }
 
   @Test
   public void testDeleteTagUrl() {
     String expectedTagsUrl = "/ng/test-org/tags/trace/test-trace";
-    assertEquals(expectedTagsUrl, urlBuilder.deleteTag(organizationId, testTrace));
+    assertThat(urlBuilder.deleteTag(organizationId, testTrace)).isEqualTo(expectedTagsUrl);
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   public void testSetStatusUrl() {
     String expectedTagsUrl = "/ng/test-org/orgtraces/mark";
-    assertEquals(expectedTagsUrl, urlBuilder.setTraceStatus(organizationId));
+    assertThat(urlBuilder.setTraceStatus(organizationId)).isEqualTo(expectedTagsUrl);
   }
 
   @Test
   public void testAgentUrls() {
     String expectedJavaUrl = "/ng/test-org/agents/default/java?jvm=1_6";
 
-    assertEquals(
-        expectedJavaUrl, urlBuilder.getAgentUrl(AgentType.JAVA, organizationId, "default"));
+    assertThat(urlBuilder.getAgentUrl(AgentType.JAVA, organizationId, "default"))
+        .isEqualTo(expectedJavaUrl);
 
     String expectedNodeWithCustomProfileUrl = "/ng/test-org/agents/customnodeprofile/node";
 
-    assertEquals(
-        expectedNodeWithCustomProfileUrl,
-        urlBuilder.getAgentUrl(AgentType.NODE, organizationId, "customnodeprofile"));
+    assertThat(urlBuilder.getAgentUrl(AgentType.NODE, organizationId, "customnodeprofile"))
+        .isEqualTo(expectedNodeWithCustomProfileUrl);
 
     String expectedDotNetProfile = "/ng/test-org/agents/default/dotnet";
 
-    assertEquals(
-        expectedDotNetProfile, urlBuilder.getAgentUrl(AgentType.DOTNET, organizationId, "default"));
+    assertThat(urlBuilder.getAgentUrl(AgentType.DOTNET, organizationId, "default"))
+        .isEqualTo(expectedDotNetProfile);
 
     String expectedRubyUrl = "/ng/test-org/agents/default/ruby";
 
-    assertEquals(
-        expectedRubyUrl, urlBuilder.getAgentUrl(AgentType.RUBY, organizationId, "default"));
+    assertThat(urlBuilder.getAgentUrl(AgentType.RUBY, organizationId, "default"))
+        .isEqualTo(expectedRubyUrl);
 
     String expectedPythonUrl = "/ng/test-org/agents/default/python";
 
-    assertEquals(
-        expectedPythonUrl, urlBuilder.getAgentUrl(AgentType.PYTHON, organizationId, "default"));
+    assertThat(urlBuilder.getAgentUrl(AgentType.PYTHON, organizationId, "default"))
+        .isEqualTo(expectedPythonUrl);
 
     String expectedDotNetCoreUrl = "/ng/test-org/agents/default/dotnet_core";
 
-    assertEquals(
-        expectedDotNetCoreUrl,
-        urlBuilder.getAgentUrl(AgentType.DOTNET_CORE, organizationId, "default"));
+    assertThat(urlBuilder.getAgentUrl(AgentType.DOTNET_CORE, organizationId, "default"))
+        .isEqualTo(expectedDotNetCoreUrl);
   }
 
   @Test
@@ -265,8 +253,7 @@ final class UrlBuilderTest {
     String expectedApplicationTrendUrl =
         "/ng/test-org/orgtraces/stats/trend/year/total?applications=test-application";
 
-    assertEquals(
-        expectedApplicationTrendUrl,
-        urlBuilder.getYearlyVulnTrendForApplicationUrl("test-org", "test-application"));
+    assertThat(urlBuilder.getYearlyVulnTrendForApplicationUrl("test-org", "test-application"))
+        .isEqualTo(expectedApplicationTrendUrl);
   }
 }


### PR DESCRIPTION
Upgrading to JUnit 5 before proposing a new test suite for verifying API interaction. Consistent with the Java Team style guide, migrate assertions to use [AssertJ](https://assertj.github.io/doc/)