### PR TITLE
👷 JAVA-3298 Cross Compile With Release Flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,18 +8,15 @@ on:
 
 jobs:
   build:
-    name: Verify Java ${{ matrix.java }}
+    name: Verify
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        java: [ '8', '11', '15' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 15
           distribution: 'adopt-hotspot'
       - name: Cache Maven Wrapper
         uses: actions/cache@v2
@@ -34,5 +31,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Verify
-        # Skip formatting check on all but JDK 11, because formatter does not support 1.8 and there's no point to running this check on every JDK
-        run: ./mvnw --batch-mode -Dspotless.check.skip=${{ matrix.java != '11' }} verify
+        run: ./mvnw --batch-mode verify

--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,7 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Use javac `--release` flag to cross compile to Java 1.8 from Java 15.

Unlike the `-source` and `-target` compiler flags we were using, the `--release` flag ensures that we only use APIs available in JDK 1.8 despite compiling with JDK 15. Likewise, compiling with JDK 15 ensures that we don't depend on an API that's been removed since JDK 1.8 (e.g. JAXB).

This helps us catch incompatibilities earlier vs running JDK 1.8, 11, and 15 in the pipeline. My take is that this change obviates the need to re-run tests in JDK 1.8, 11, and 15.