### PR TITLE
♻️ JAVA-3298 Clean-Up Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <groupId>com.contrastsecurity</groupId>
   <artifactId>contrast-sdk-java</artifactId>
   <version>3.2-SNAPSHOT</version>
 
   <organization>
     <name>Contrast Security</name>
-    <url>contrastsecurity.com</url>
+    <url>https://contrastsecurity.com</url>
   </organization>
 
   <distributionManagement>
@@ -31,7 +25,7 @@
   </distributionManagement>
 
   <name>Contrast Java SDK</name>
-  <description>SDK for accessing and using the Contrast TeamServer REST API in Java</description>
+  <description>Java SDK for using Contrast Security APIs</description>
 
   <scm>
     <connection>scm:git:https://github.com/Contrast-Security-OSS/contrast-sdk-java.git</connection>
@@ -40,6 +34,10 @@
     </developerConnection>
     <tag>HEAD</tag>
   </scm>
+
+  <properties>
+    <localTeamServerUrl>http://localhost:19080/Contrast/api</localTeamServerUrl>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -70,12 +68,6 @@
       <version>2.6.2</version>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.18</version>
@@ -92,35 +84,31 @@
     </testResources>
     <plugins>
       <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-scm-plugin</artifactId>
-            <version>1.8.1</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.4.0</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>enforce</goal>
             </goals>
+            <configuration>
+              <rules>
+                <dependencyConvergence/>
+                <requirePluginVersions/>
+                <requireSameVersions>
+                  <plugins>
+                    <plugin>org.apache.maven.plugins:maven-surefire-plugin</plugin>
+                    <plugin>org.apache.maven.plugins:maven-failsafe-plugin</plugin>
+                    <plugin>org.apache.maven.plugins:maven-surefire-report-plugin</plugin>
+                  </plugins>
+                </requireSameVersions>
+                <requireReleaseDeps/>
+              </rules>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <mainClass>com.contrastsecurity.sdk.ContrastSDK</mainClass>
-          <arguments>
-          </arguments>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <executions>
           <execution>
@@ -145,6 +133,13 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <detectJavaApiLink>false</detectJavaApiLink>
@@ -160,6 +155,14 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/ScreenerTest.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <executions>
           <execution>
@@ -172,27 +175,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
-        <configuration>
-          <excludes>
-            <exclude>**/ScreenerTest.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.12.2</version>
         <configuration>
           <formats>
             <format>
@@ -229,18 +213,81 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-scm-plugin</artifactId>
+          <version>1.11.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.9.1</version>
+        </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.12.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.8</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
-
-  <properties>
-    <localTeamServerUrl>http://localhost:19080/Contrast/api</localTeamServerUrl>
-    <stagingTeamServerUrl>http://teamserver-334.internal.contsec.com/Contrast/api
-    </stagingTeamServerUrl>
-
-    <versions.maven-source-plugin>3.0.1</versions.maven-source-plugin>
-    <versions.maven-javadoc-plugin>3.0.0</versions.maven-javadoc-plugin>
-    <versions.maven-gpg-plugin>1.6</versions.maven-gpg-plugin>
-    <versions.nexus-staging-maven-plugin>1.6.8</versions.nexus-staging-maven-plugin>
-  </properties>
 
   <profiles>
     <profile>
@@ -250,7 +297,6 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${versions.nexus-staging-maven-plugin}</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -259,9 +305,7 @@
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>${versions.maven-source-plugin}</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -272,9 +316,7 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${versions.maven-javadoc-plugin}</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -285,9 +327,7 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>${versions.maven-gpg-plugin}</version>
             <configuration>
               <gpgArguments>
                 <arg>--batch</arg>
@@ -310,5 +350,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
* Configures [maven-enforcer-plugin](https://maven.apache.org/enforcer/enforcer-rules/index.html) to enforce good practices.
* Use explicit versions for all plugins (defined in `pluginManagement`).
* Remove parent pom with old deployment workflow - we use the `release` profile and the `nexus-staging-maven-plugin` now.