### PR TITLE
Add support for servers in library reponses

### DIFF
--- a/src/main/java/com/contrastsecurity/models/Library.java
+++ b/src/main/java/com/contrastsecurity/models/Library.java
@@ -64,6 +64,12 @@ public class Library {
 
   private List<Application> apps;
 
+  public List<Server> getServers() {
+    return servers;
+  }
+
+  private List<Server> servers;
+
   /**
    * Return the number of classes in this library.
    *


### PR DESCRIPTION
When expanding `apps` in library responses (see #87) the API returns the servers for the libraries.
Enable serializing the servers in the responses.