### PR TITLE
Added Query to facade the change for naming FilterForms to Queries

### DIFF
--- a/src/main/java/com/contrastsecurity/exceptions/QueryException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/QueryException.java
@@ -1,5 +1,3 @@
 package com.contrastsecurity.exceptions;
 
-public class QueryException extends Exception {
-
-}
+public class QueryException extends Exception {}

--- a/src/main/java/com/contrastsecurity/exceptions/QueryException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/QueryException.java
@@ -1,0 +1,5 @@
+package com.contrastsecurity.exceptions;
+
+public class QueryException extends Exception {
+
+}

--- a/src/main/java/com/contrastsecurity/http/FilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/FilterForm.java
@@ -6,9 +6,7 @@ import java.util.EnumSet;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 
-/**
- * @deprecated FilterForms are being replaced with {@link Query}
- */
+/** @deprecated FilterForms are being replaced with {@link Query} */
 @Deprecated
 public class FilterForm {
 

--- a/src/main/java/com/contrastsecurity/http/FilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/FilterForm.java
@@ -6,6 +6,10 @@ import java.util.EnumSet;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 
+/**
+ * @deprecated FilterForms are being replaced with {@link Query}
+ */
+@Deprecated
 public class FilterForm {
 
   public enum ApplicationExpandValues {

--- a/src/main/java/com/contrastsecurity/http/Query.java
+++ b/src/main/java/com/contrastsecurity/http/Query.java
@@ -1,13 +1,16 @@
 package com.contrastsecurity.http;
 
+import com.contrastsecurity.exceptions.QueryException;
+
 public class Query extends FilterForm {
 
   /**
    * Returns the query into url parameters
    *
    * @return the query into url parameters
+   * @throws QueryException when an exception occurs converting to url parameters
    */
-  public String toQuery() {
+  public String toQuery() throws QueryException {
     return super.toString();
   }
 }

--- a/src/main/java/com/contrastsecurity/http/Query.java
+++ b/src/main/java/com/contrastsecurity/http/Query.java
@@ -1,8 +1,11 @@
 package com.contrastsecurity.http;
 
 import com.contrastsecurity.exceptions.QueryException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
 
 public class Query<T extends Query<T>> {
   private EnumSet<?> expand;
@@ -97,6 +100,36 @@ public class Query<T extends Query<T>> {
    * @throws QueryException when an exception occurs converting to url parameters
    */
   public String toQuery() throws QueryException {
-    return super.toString();
+    List<String> filters = new ArrayList<>();
+
+    if (expand != null && !expand.isEmpty()) {
+      filters.add("expand=" + StringUtils.join(expand, ","));
+    }
+
+    if (limit > 0) {
+      filters.add("limit=" + limit);
+    }
+
+    if (offset > 0) {
+      filters.add("offset=" + offset);
+    }
+
+    if (startDate != null) {
+      filters.add("startDate=" + startDate.getTime());
+    }
+
+    if (endDate != null) {
+      filters.add("endDate=" + endDate.getTime());
+    }
+
+    if (!StringUtils.isEmpty(sort)) {
+      filters.add("sort=" + sort);
+    }
+
+    if (!filters.isEmpty()) {
+      return "?" + StringUtils.join(filters, "&");
+    } else {
+      return "";
+    }
   }
 }

--- a/src/main/java/com/contrastsecurity/http/Query.java
+++ b/src/main/java/com/contrastsecurity/http/Query.java
@@ -1,8 +1,94 @@
 package com.contrastsecurity.http;
 
 import com.contrastsecurity.exceptions.QueryException;
+import java.util.Date;
+import java.util.EnumSet;
 
-public class Query extends FilterForm {
+public class Query<T extends Query<T>> {
+  private EnumSet<?> expand;
+  private int limit;
+  private int offset;
+  private Date startDate;
+  private Date endDate;
+  private String sort;
+
+  public Query() {
+    this.expand = null;
+    this.limit = 0;
+    this.offset = 0;
+    this.startDate = null;
+    this.endDate = null;
+    this.sort = "";
+  }
+
+  public Query(
+      EnumSet<?> expand, int limit, int offset, Date startDate, Date endDate, String sort) {
+    this.expand = expand;
+    this.limit = limit;
+    this.offset = offset;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.sort = sort;
+  }
+
+  public EnumSet<?> getExpand() {
+    return expand;
+  }
+
+  public T setExpand(EnumSet<?> expand) {
+    this.expand = expand;
+    return self();
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public T setLimit(int limit) {
+    this.limit = limit;
+    return self();
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public T setOffset(int offset) {
+    this.offset = offset;
+    return self();
+  }
+
+  public Date getStartDate() {
+    return startDate;
+  }
+
+  public T setStartDate(Date startDate) {
+    this.startDate = startDate;
+    return self();
+  }
+
+  public Date getEndDate() {
+    return endDate;
+  }
+
+  public T setEndDate(Date endDate) {
+    this.endDate = endDate;
+    return self();
+  }
+
+  public String getSort() {
+    return sort;
+  }
+
+  public T setSort(String sort) {
+    this.sort = sort;
+    return self();
+  }
+
+  @SuppressWarnings("unchecked")
+  private T self() {
+    return (T) this;
+  }
 
   /**
    * Returns the query into url parameters

--- a/src/main/java/com/contrastsecurity/http/Query.java
+++ b/src/main/java/com/contrastsecurity/http/Query.java
@@ -1,9 +1,10 @@
 package com.contrastsecurity.http;
 
-public class Query extends FilterForm{
+public class Query extends FilterForm {
 
   /**
    * Returns the query into url parameters
+   *
    * @return the query into url parameters
    */
   public String toQuery() {

--- a/src/main/java/com/contrastsecurity/http/Query.java
+++ b/src/main/java/com/contrastsecurity/http/Query.java
@@ -1,0 +1,12 @@
+package com.contrastsecurity.http;
+
+public class Query extends FilterForm{
+
+  /**
+   * Returns the query into url parameters
+   * @return the query into url parameters
+   */
+  public String toQuery() {
+    return super.toString();
+  }
+}

--- a/src/test/java/com/contrastsecurity/QueryTest.java
+++ b/src/test/java/com/contrastsecurity/QueryTest.java
@@ -1,0 +1,60 @@
+package com.contrastsecurity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contrastsecurity.exceptions.QueryException;
+import com.contrastsecurity.http.ApplicationFilterForm;
+import com.contrastsecurity.http.ApplicationFilterForm.ApplicationExpandValues;
+import com.contrastsecurity.http.Query;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class QueryTest {
+  Query<?> query;
+
+  @BeforeEach
+  public void before() {
+    query = new Query<>();
+  }
+
+  @Test
+  @DisplayName("Test toQuery only returns url parameters with set parameters")
+  public void testBasicQuery() throws QueryException {
+    query.setLimit(10).setOffset(10);
+
+    String queryString = query.toQuery();
+
+    assertThat(queryString).contains("limit");
+    assertThat(queryString).contains("offset");
+    assertThat(queryString).doesNotContain("sort");
+    assertThat(queryString).doesNotContain("startDate");
+  }
+
+  @Test
+  @DisplayName("Test toQuery with expand set returns the expanded list")
+  public void testQueryWithExpand() throws QueryException {
+    EnumSet<ApplicationFilterForm.ApplicationExpandValues> expand =
+        EnumSet.of(ApplicationExpandValues.SCORES, ApplicationExpandValues.LICENSE);
+
+    query.setExpand(expand);
+
+    String queryString = query.toQuery();
+
+    String expandValues = queryString.split("=")[1];
+    ArrayList<String> values = new ArrayList<>(Arrays.asList(expandValues.split(",")));
+
+    assertThat(queryString).isNotEmpty();
+    assertThat(queryString).contains("expand");
+
+    assertThat(values).contains("scores");
+    assertThat(values).contains("license");
+
+    assertThat(values).doesNotContain("apps");
+    assertThat(values).doesNotContain("test");
+    assertThat(values).doesNotContain("libs");
+  }
+}


### PR DESCRIPTION
# Background
We are moving to naming FilterForm as Query.

# Purpose
This adds a Query class so that new Query will extend a Query class instead of a FilterForm class.

# What changed
1. Marked FilterForm as deprecated
2. Added Query to act as a facade for new Queries. When FilterForm is removed in the next major version, it will move to Query.
3. Added QueryException so that we can throw exceptions during the toQuery method instead of swallowing and returning a string.