### PR TITLE
✨ JAVA-3298 Provide High-Level Wrapper for Scan Summary Duration

### DIFF
--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
@@ -1,5 +1,6 @@
 package com.contrastsecurity.sdk.scan;
 
+import java.time.Duration;
 import java.time.Instant;
 
 /** Summary of a Scan and its results. */
@@ -17,8 +18,8 @@ public interface ScanSummary {
   /** @return ID of the Contrast organization */
   String organizationId();
 
-  /** @return duration of the scan in milliseconds */
-  long duration();
+  /** @return duration of the scan */
+  Duration duration();
 
   /** @return number of vulnerabilities detected in this scan */
   int totalResults();

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
@@ -1,5 +1,6 @@
 package com.contrastsecurity.sdk.scan;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -33,8 +34,8 @@ final class ScanSummaryImpl implements ScanSummary {
   }
 
   @Override
-  public long duration() {
-    return inner.duration();
+  public Duration duration() {
+    return Duration.ofMillis(inner.duration());
   }
 
   @Override

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
@@ -1,5 +1,6 @@
 package com.contrastsecurity.sdk.scan;
 
+import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 
@@ -30,7 +31,7 @@ final class ScanSummaryAssert extends AbstractAssert<ScanSummaryAssert, ScanSumm
     Assertions.assertThat(actual.projectId()).isEqualTo(inner.projectId());
     Assertions.assertThat(actual.organizationId()).isEqualTo(inner.organizationId());
     Assertions.assertThat(actual.createdDate()).isEqualTo(inner.createdDate());
-    Assertions.assertThat(actual.duration()).isEqualTo(inner.duration());
+    Assertions.assertThat(actual.duration()).isEqualTo(Duration.ofMillis(inner.duration()));
     Assertions.assertThat(actual.totalNewResults()).isEqualTo(inner.totalNewResults());
     Assertions.assertThat(actual.totalFixedResults()).isEqualTo(inner.totalFixedResults());
     Assertions.assertThat(actual.totalResults()).isEqualTo(inner.totalResults());


### PR DESCRIPTION
I forgot a commit 🤦 .

This wraps the low-level `duration` accessor with a high-level accessor.