### PR TITLE
update build java version to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 15
+          java-version: 16
           distribution: temurin
       - name: Cache Maven Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 15
-          distribution: 'adopt-hotspot'
+          distribution: temurin
       - name: Cache Maven Wrapper
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,18 @@ on:
 
 jobs:
   build:
-    name: Verify
+    name: Verify Java ${{ matrix.java}}
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: ['11', '16']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 16
+          java-version: ${{ matrix.java }}
           distribution: temurin
       - name: Cache Maven Wrapper
         uses: actions/cache@v2
@@ -31,4 +34,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Verify
-        run: ./mvnw --batch-mode verify
+        run: ./mvnw --batch-mode -Dspotless.check.skip=${{matrix.java == '16'}} verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,18 +8,15 @@ on:
 
 jobs:
   build:
-    name: Verify Java ${{ matrix.java}}
+    name: Verify
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        java: ['11', '16']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
           distribution: temurin
       - name: Cache Maven Wrapper
         uses: actions/cache@v2
@@ -34,4 +31,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Verify
-        run: ./mvnw --batch-mode -Dspotless.check.skip=${{matrix.java == '16'}} verify
+        run: ./mvnw --batch-mode verify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,41 +5,66 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+    environment: Maven Central
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: temurin
           server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
-      - name: validate
-        run: mvn clean test
-      - name: import gpg
-        run: |
-          echo ${{secrets.GPG_SECRET_KEYS}} | base64 --decode | gpg --import --no-tty --batch --yes
-      - name: build
+
+      - name: Cache Maven Wrapper
+        uses: actions/cache@v2
+        with:
+          path: ./.mvn/wrapper/maven-wrapper.jar
+          key: ${{ runner.os }}-maven-wrapper-${{ hashFiles('./.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-maven-wrapper
+
+      - name: Cache Maven Packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Install pinentry
+        run: sudo apt-get install pinentry-tty
+
+      - name: Build
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn clean install -DskipTests -Prelease
-      - name: Maven release (dry-run)
+        run: ./mvnw --batch-mode verify -Prelease
+
+      - name: Maven Release (dry-run)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          mvn -Darguments="-DskipTests=true" -DdryRun=true --batch-mode release:prepare release:perform -Dusername=$GITHUB_ACTOR -Dpassword=$GITHUB_TOKEN -Prelease
-      - name: Maven release
+          ./mvnw -Darguments="-DskipTests=true" -DdryRun=true --batch-mode release:prepare release:perform -Dusername=$GITHUB_ACTOR -Dpassword=$GITHUB_TOKEN -Prelease
+
+      # See https://github.com/actions/checkout/issues/13
+      - name: Configure Git User
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Maven Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          git config --global user.name 'Github'
-          git config --global user.email 'github@users.noreply.github.com'
-          mvn -Darguments="-DskipTests=true" --batch-mode release:prepare release:perform -Dusername=$GITHUB_ACTOR -Dpassword=$GITHUB_TOKEN -Prelease
+          ./mvnw -Darguments="-DskipTests=true" --batch-mode release:prepare release:perform -Dusername=$GITHUB_ACTOR -Dpassword=$GITHUB_TOKEN -Prelease

--- a/pom.xml
+++ b/pom.xml
@@ -135,18 +135,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>deploy</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>
@@ -490,14 +478,6 @@
           </plugin>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <configuration>
-              <gpgArguments>
-                <arg>--batch</arg>
-                <arg>--yes</arg>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -505,6 +485,12 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <localTeamServerUrl>http://localhost:19080/Contrast/api</localTeamServerUrl>
     <versions.junit-jupiter>5.7.1</versions.junit-jupiter>
     <versions.auto-value>1.8.2</versions.auto-value>
-    <versions.lombok>1.18.18</versions.lombok>
+    <versions.lombok>1.18.20</versions.lombok>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.12.0</version>
+          <version>2.12.3</version>
           <configuration>
             <formats>
               <format>


### PR DESCRIPTION
Looks like temurin only has 8, 11, and 16. Java 16 is not compatible with the latest versions of spotless and javadoc plugins. spotless has a workaround but we can't use it since we are targeting java 8.

Setting the build workflow to use 11, until our dependencies get updated to 16.