### PR TITLE
INT-1102 update copyright dates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 - 2022 Contrast Security, Inc.
+Copyright 2022 Contrast Security, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Contrast Security, Inc.
+Copyright 2014 - 2022 Contrast Security, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <versions.junit-jupiter>5.7.1</versions.junit-jupiter>
     <versions.auto-value>1.8.2</versions.auto-value>
     <versions.lombok>1.18.18</versions.lombok>
+    <copyrightYear>2022</copyrightYear>
   </properties>
 
   <dependencies>
@@ -354,7 +355,7 @@
           <version>2.0.0</version>
           <configuration>
             <licenseName>apache_v2</licenseName>
-            <inceptionYear>2014</inceptionYear>
+            <inceptionYear>${copyrightYear}</inceptionYear>
             <canUpdateCopyright>true</canUpdateCopyright>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,8 @@
           <version>2.0.0</version>
           <configuration>
             <licenseName>apache_v2</licenseName>
-            <inceptionYear>2021</inceptionYear>
+            <inceptionYear>2014</inceptionYear>
+            <canUpdateCopyright>true</canUpdateCopyright>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java-templates/com/contrastsecurity/sdk/Version.java
+++ b/src/main/java-templates/com/contrastsecurity/sdk/Version.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java-templates/com/contrastsecurity/sdk/Version.java
+++ b/src/main/java-templates/com/contrastsecurity/sdk/Version.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ConfigurationException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ConfigurationException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ConfigurationException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ConfigurationException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ContrastException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ContrastException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ContrastException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ContrastException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/HttpResponseException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/HttpResponseException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/HttpResponseException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/HttpResponseException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.exceptions;
 
 /*-

--- a/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.exceptions;
 
 /*-

--- a/src/main/java/com/contrastsecurity/exceptions/ServerResponseException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ServerResponseException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/ServerResponseException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/ServerResponseException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
+++ b/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.exceptions;
 
 /*-

--- a/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/FilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/FilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/FilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/FilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/HttpMethod.java
+++ b/src/main/java/com/contrastsecurity/http/HttpMethod.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/HttpMethod.java
+++ b/src/main/java/com/contrastsecurity/http/HttpMethod.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
+++ b/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
+++ b/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/MediaType.java
+++ b/src/main/java/com/contrastsecurity/http/MediaType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/MediaType.java
+++ b/src/main/java/com/contrastsecurity/http/MediaType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/RequestConstants.java
+++ b/src/main/java/com/contrastsecurity/http/RequestConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/RequestConstants.java
+++ b/src/main/java/com/contrastsecurity/http/RequestConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/RequestUrlConstants.java
+++ b/src/main/java/com/contrastsecurity/http/RequestUrlConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/RequestUrlConstants.java
+++ b/src/main/java/com/contrastsecurity/http/RequestUrlConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/RuleSeverity.java
+++ b/src/main/java/com/contrastsecurity/http/RuleSeverity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/RuleSeverity.java
+++ b/src/main/java/com/contrastsecurity/http/RuleSeverity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckFilter.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckFilter.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
+++ b/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/ServerEnvironment.java
+++ b/src/main/java/com/contrastsecurity/http/ServerEnvironment.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/ServerEnvironment.java
+++ b/src/main/java/com/contrastsecurity/http/ServerEnvironment.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/ServerFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/ServerFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/ServerFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/ServerFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/TraceFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/TraceFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/TraceFilterForm.java
+++ b/src/main/java/com/contrastsecurity/http/TraceFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/TraceFilterKeycode.java
+++ b/src/main/java/com/contrastsecurity/http/TraceFilterKeycode.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/TraceFilterKeycode.java
+++ b/src/main/java/com/contrastsecurity/http/TraceFilterKeycode.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/TraceFilterType.java
+++ b/src/main/java/com/contrastsecurity/http/TraceFilterType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/TraceFilterType.java
+++ b/src/main/java/com/contrastsecurity/http/TraceFilterType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/AgentType.java
+++ b/src/main/java/com/contrastsecurity/models/AgentType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/AgentType.java
+++ b/src/main/java/com/contrastsecurity/models/AgentType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Application.java
+++ b/src/main/java/com/contrastsecurity/models/Application.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Application.java
+++ b/src/main/java/com/contrastsecurity/models/Application.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Application.java
+++ b/src/main/java/com/contrastsecurity/models/Application.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/ApplicationImportance.java
+++ b/src/main/java/com/contrastsecurity/models/ApplicationImportance.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/ApplicationImportance.java
+++ b/src/main/java/com/contrastsecurity/models/ApplicationImportance.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Applications.java
+++ b/src/main/java/com/contrastsecurity/models/Applications.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Applications.java
+++ b/src/main/java/com/contrastsecurity/models/Applications.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/AssessLicenseOverview.java
+++ b/src/main/java/com/contrastsecurity/models/AssessLicenseOverview.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/AssessLicenseOverview.java
+++ b/src/main/java/com/contrastsecurity/models/AssessLicenseOverview.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Card.java
+++ b/src/main/java/com/contrastsecurity/models/Card.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Card.java
+++ b/src/main/java/com/contrastsecurity/models/Card.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Chapter.java
+++ b/src/main/java/com/contrastsecurity/models/Chapter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Chapter.java
+++ b/src/main/java/com/contrastsecurity/models/Chapter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/CodeObject.java
+++ b/src/main/java/com/contrastsecurity/models/CodeObject.java
@@ -33,7 +33,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/CodeObject.java
+++ b/src/main/java/com/contrastsecurity/models/CodeObject.java
@@ -1,32 +1,3 @@
-/*
- * Copyright (c) 2013, Contrast Security, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/CodeObject.java
+++ b/src/main/java/com/contrastsecurity/models/CodeObject.java
@@ -33,7 +33,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Coverage.java
+++ b/src/main/java/com/contrastsecurity/models/Coverage.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Coverage.java
+++ b/src/main/java/com/contrastsecurity/models/Coverage.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Coverage.java
+++ b/src/main/java/com/contrastsecurity/models/Coverage.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/CustomRecommendation.java
+++ b/src/main/java/com/contrastsecurity/models/CustomRecommendation.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/CustomRecommendation.java
+++ b/src/main/java/com/contrastsecurity/models/CustomRecommendation.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/CustomRuleReferences.java
+++ b/src/main/java/com/contrastsecurity/models/CustomRuleReferences.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/CustomRuleReferences.java
+++ b/src/main/java/com/contrastsecurity/models/CustomRuleReferences.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Event.java
+++ b/src/main/java/com/contrastsecurity/models/Event.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Event.java
+++ b/src/main/java/com/contrastsecurity/models/Event.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventDetails.java
+++ b/src/main/java/com/contrastsecurity/models/EventDetails.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventDetails.java
+++ b/src/main/java/com/contrastsecurity/models/EventDetails.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventItem.java
+++ b/src/main/java/com/contrastsecurity/models/EventItem.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventItem.java
+++ b/src/main/java/com/contrastsecurity/models/EventItem.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventModel.java
+++ b/src/main/java/com/contrastsecurity/models/EventModel.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventModel.java
+++ b/src/main/java/com/contrastsecurity/models/EventModel.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventResource.java
+++ b/src/main/java/com/contrastsecurity/models/EventResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventResource.java
+++ b/src/main/java/com/contrastsecurity/models/EventResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventSummaryResponse.java
+++ b/src/main/java/com/contrastsecurity/models/EventSummaryResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/EventSummaryResponse.java
+++ b/src/main/java/com/contrastsecurity/models/EventSummaryResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/FreeformMetadata.java
+++ b/src/main/java/com/contrastsecurity/models/FreeformMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/FreeformMetadata.java
+++ b/src/main/java/com/contrastsecurity/models/FreeformMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/GenericResponse.java
+++ b/src/main/java/com/contrastsecurity/models/GenericResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/GenericResponse.java
+++ b/src/main/java/com/contrastsecurity/models/GenericResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/HttpRequest.java
+++ b/src/main/java/com/contrastsecurity/models/HttpRequest.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/HttpRequest.java
+++ b/src/main/java/com/contrastsecurity/models/HttpRequest.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/HttpRequest.java
+++ b/src/main/java/com/contrastsecurity/models/HttpRequest.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/HttpRequestResponse.java
+++ b/src/main/java/com/contrastsecurity/models/HttpRequestResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/HttpRequestResponse.java
+++ b/src/main/java/com/contrastsecurity/models/HttpRequestResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
+++ b/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
+++ b/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/JobOutcomePolicySeverity.java
+++ b/src/main/java/com/contrastsecurity/models/JobOutcomePolicySeverity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/JobOutcomePolicySeverity.java
+++ b/src/main/java/com/contrastsecurity/models/JobOutcomePolicySeverity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Libraries.java
+++ b/src/main/java/com/contrastsecurity/models/Libraries.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Libraries.java
+++ b/src/main/java/com/contrastsecurity/models/Libraries.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Library.java
+++ b/src/main/java/com/contrastsecurity/models/Library.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Library.java
+++ b/src/main/java/com/contrastsecurity/models/Library.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Library.java
+++ b/src/main/java/com/contrastsecurity/models/Library.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/LibraryScores.java
+++ b/src/main/java/com/contrastsecurity/models/LibraryScores.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/LibraryScores.java
+++ b/src/main/java/com/contrastsecurity/models/LibraryScores.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/LibraryStats.java
+++ b/src/main/java/com/contrastsecurity/models/LibraryStats.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/LibraryStats.java
+++ b/src/main/java/com/contrastsecurity/models/LibraryStats.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/LibraryVulnerability.java
+++ b/src/main/java/com/contrastsecurity/models/LibraryVulnerability.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/LibraryVulnerability.java
+++ b/src/main/java/com/contrastsecurity/models/LibraryVulnerability.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/License.java
+++ b/src/main/java/com/contrastsecurity/models/License.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/License.java
+++ b/src/main/java/com/contrastsecurity/models/License.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Login.java
+++ b/src/main/java/com/contrastsecurity/models/Login.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Login.java
+++ b/src/main/java/com/contrastsecurity/models/Login.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Login.java
+++ b/src/main/java/com/contrastsecurity/models/Login.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2018, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/MakeRequestResponse.java
+++ b/src/main/java/com/contrastsecurity/models/MakeRequestResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MakeRequestResponse.java
+++ b/src/main/java/com/contrastsecurity/models/MakeRequestResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataEntity.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataEntity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataEntity.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataEntity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataFilterGroup.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataFilterGroup.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataFilterGroup.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataFilterGroup.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataFilterResponse.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataFilterResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataFilterResponse.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataFilterResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataFilterValue.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataFilterValue.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/MetadataFilterValue.java
+++ b/src/main/java/com/contrastsecurity/models/MetadataFilterValue.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NameValuePair.java
+++ b/src/main/java/com/contrastsecurity/models/NameValuePair.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NameValuePair.java
+++ b/src/main/java/com/contrastsecurity/models/NameValuePair.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NameValuePair.java
+++ b/src/main/java/com/contrastsecurity/models/NameValuePair.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/NotificationResource.java
+++ b/src/main/java/com/contrastsecurity/models/NotificationResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NotificationResource.java
+++ b/src/main/java/com/contrastsecurity/models/NotificationResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NotificationsResponse.java
+++ b/src/main/java/com/contrastsecurity/models/NotificationsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NotificationsResponse.java
+++ b/src/main/java/com/contrastsecurity/models/NotificationsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NumericMetadata.java
+++ b/src/main/java/com/contrastsecurity/models/NumericMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/NumericMetadata.java
+++ b/src/main/java/com/contrastsecurity/models/NumericMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Organization.java
+++ b/src/main/java/com/contrastsecurity/models/Organization.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Organization.java
+++ b/src/main/java/com/contrastsecurity/models/Organization.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Organizations.java
+++ b/src/main/java/com/contrastsecurity/models/Organizations.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Organizations.java
+++ b/src/main/java/com/contrastsecurity/models/Organizations.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Parameter.java
+++ b/src/main/java/com/contrastsecurity/models/Parameter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Parameter.java
+++ b/src/main/java/com/contrastsecurity/models/Parameter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/PointOfContactMetadata.java
+++ b/src/main/java/com/contrastsecurity/models/PointOfContactMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/PointOfContactMetadata.java
+++ b/src/main/java/com/contrastsecurity/models/PointOfContactMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/PropertyResource.java
+++ b/src/main/java/com/contrastsecurity/models/PropertyResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/PropertyResource.java
+++ b/src/main/java/com/contrastsecurity/models/PropertyResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Recommendation.java
+++ b/src/main/java/com/contrastsecurity/models/Recommendation.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Recommendation.java
+++ b/src/main/java/com/contrastsecurity/models/Recommendation.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RecommendationResponse.java
+++ b/src/main/java/com/contrastsecurity/models/RecommendationResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RecommendationResponse.java
+++ b/src/main/java/com/contrastsecurity/models/RecommendationResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Risk.java
+++ b/src/main/java/com/contrastsecurity/models/Risk.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Risk.java
+++ b/src/main/java/com/contrastsecurity/models/Risk.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageBySessionIDAndMetadataRequest.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageBySessionIDAndMetadataRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageBySessionIDAndMetadataRequest.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageBySessionIDAndMetadataRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageMetadataLabelValues.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageMetadataLabelValues.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageMetadataLabelValues.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageMetadataLabelValues.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
+++ b/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/RuleReferences.java
+++ b/src/main/java/com/contrastsecurity/models/RuleReferences.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/RuleReferences.java
+++ b/src/main/java/com/contrastsecurity/models/RuleReferences.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Rules.java
+++ b/src/main/java/com/contrastsecurity/models/Rules.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Rules.java
+++ b/src/main/java/com/contrastsecurity/models/Rules.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/ScanPagedResult.java
+++ b/src/main/java/com/contrastsecurity/models/ScanPagedResult.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/ScanPagedResult.java
+++ b/src/main/java/com/contrastsecurity/models/ScanPagedResult.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Scores.java
+++ b/src/main/java/com/contrastsecurity/models/Scores.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Scores.java
+++ b/src/main/java/com/contrastsecurity/models/Scores.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/SecurityCheck.java
+++ b/src/main/java/com/contrastsecurity/models/SecurityCheck.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/SecurityCheck.java
+++ b/src/main/java/com/contrastsecurity/models/SecurityCheck.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Server.java
+++ b/src/main/java/com/contrastsecurity/models/Server.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Server.java
+++ b/src/main/java/com/contrastsecurity/models/Server.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Server.java
+++ b/src/main/java/com/contrastsecurity/models/Server.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/ServerTagsResponse.java
+++ b/src/main/java/com/contrastsecurity/models/ServerTagsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/ServerTagsResponse.java
+++ b/src/main/java/com/contrastsecurity/models/ServerTagsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Servers.java
+++ b/src/main/java/com/contrastsecurity/models/Servers.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Servers.java
+++ b/src/main/java/com/contrastsecurity/models/Servers.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Servers.java
+++ b/src/main/java/com/contrastsecurity/models/Servers.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/SignUp.java
+++ b/src/main/java/com/contrastsecurity/models/SignUp.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/SignUp.java
+++ b/src/main/java/com/contrastsecurity/models/SignUp.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/SignUp.java
+++ b/src/main/java/com/contrastsecurity/models/SignUp.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2018, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/Stacktrace.java
+++ b/src/main/java/com/contrastsecurity/models/Stacktrace.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Stacktrace.java
+++ b/src/main/java/com/contrastsecurity/models/Stacktrace.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/StatusRequest.java
+++ b/src/main/java/com/contrastsecurity/models/StatusRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/StatusRequest.java
+++ b/src/main/java/com/contrastsecurity/models/StatusRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Story.java
+++ b/src/main/java/com/contrastsecurity/models/Story.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Story.java
+++ b/src/main/java/com/contrastsecurity/models/Story.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/StoryResponse.java
+++ b/src/main/java/com/contrastsecurity/models/StoryResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/StoryResponse.java
+++ b/src/main/java/com/contrastsecurity/models/StoryResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Tag.java
+++ b/src/main/java/com/contrastsecurity/models/Tag.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Tag.java
+++ b/src/main/java/com/contrastsecurity/models/Tag.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Tags.java
+++ b/src/main/java/com/contrastsecurity/models/Tags.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Tags.java
+++ b/src/main/java/com/contrastsecurity/models/Tags.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TagsResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TagsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TagsResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TagsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Trace.java
+++ b/src/main/java/com/contrastsecurity/models/Trace.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Trace.java
+++ b/src/main/java/com/contrastsecurity/models/Trace.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Trace.java
+++ b/src/main/java/com/contrastsecurity/models/Trace.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/TraceBreakdown.java
+++ b/src/main/java/com/contrastsecurity/models/TraceBreakdown.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceBreakdown.java
+++ b/src/main/java/com/contrastsecurity/models/TraceBreakdown.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceEvent.java
+++ b/src/main/java/com/contrastsecurity/models/TraceEvent.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceEvent.java
+++ b/src/main/java/com/contrastsecurity/models/TraceEvent.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceEvent.java
+++ b/src/main/java/com/contrastsecurity/models/TraceEvent.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/TraceFilter.java
+++ b/src/main/java/com/contrastsecurity/models/TraceFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceFilter.java
+++ b/src/main/java/com/contrastsecurity/models/TraceFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceFilterBody.java
+++ b/src/main/java/com/contrastsecurity/models/TraceFilterBody.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceFilterBody.java
+++ b/src/main/java/com/contrastsecurity/models/TraceFilterBody.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceListing.java
+++ b/src/main/java/com/contrastsecurity/models/TraceListing.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceListing.java
+++ b/src/main/java/com/contrastsecurity/models/TraceListing.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceMetadataFilter.java
+++ b/src/main/java/com/contrastsecurity/models/TraceMetadataFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceMetadataFilter.java
+++ b/src/main/java/com/contrastsecurity/models/TraceMetadataFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceNote.java
+++ b/src/main/java/com/contrastsecurity/models/TraceNote.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceNote.java
+++ b/src/main/java/com/contrastsecurity/models/TraceNote.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceNoteResource.java
+++ b/src/main/java/com/contrastsecurity/models/TraceNoteResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceNoteResource.java
+++ b/src/main/java/com/contrastsecurity/models/TraceNoteResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceNotesResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TraceNotesResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceNotesResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TraceNotesResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceTimestampField.java
+++ b/src/main/java/com/contrastsecurity/models/TraceTimestampField.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TraceTimestampField.java
+++ b/src/main/java/com/contrastsecurity/models/TraceTimestampField.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Traces.java
+++ b/src/main/java/com/contrastsecurity/models/Traces.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Traces.java
+++ b/src/main/java/com/contrastsecurity/models/Traces.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Traces.java
+++ b/src/main/java/com/contrastsecurity/models/Traces.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
+++ b/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/URLEntry.java
+++ b/src/main/java/com/contrastsecurity/models/URLEntry.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/URLEntry.java
+++ b/src/main/java/com/contrastsecurity/models/URLEntry.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/URLEntry.java
+++ b/src/main/java/com/contrastsecurity/models/URLEntry.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/User.java
+++ b/src/main/java/com/contrastsecurity/models/User.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/User.java
+++ b/src/main/java/com/contrastsecurity/models/User.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/User.java
+++ b/src/main/java/com/contrastsecurity/models/User.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2014, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/Users.java
+++ b/src/main/java/com/contrastsecurity/models/Users.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Users.java
+++ b/src/main/java/com/contrastsecurity/models/Users.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/Users.java
+++ b/src/main/java/com/contrastsecurity/models/Users.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2018, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.models;
 
 /*-

--- a/src/main/java/com/contrastsecurity/models/VulnerabilityQuickFilterType.java
+++ b/src/main/java/com/contrastsecurity/models/VulnerabilityQuickFilterType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/VulnerabilityQuickFilterType.java
+++ b/src/main/java/com/contrastsecurity/models/VulnerabilityQuickFilterType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/VulnerabilityTrend.java
+++ b/src/main/java/com/contrastsecurity/models/VulnerabilityTrend.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/VulnerabilityTrend.java
+++ b/src/main/java/com/contrastsecurity/models/VulnerabilityTrend.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
+++ b/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models.dtm;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
+++ b/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models.dtm;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/dtm/AttestationCreateRequest.java
+++ b/src/main/java/com/contrastsecurity/models/dtm/AttestationCreateRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models.dtm;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/models/dtm/AttestationCreateRequest.java
+++ b/src/main/java/com/contrastsecurity/models/dtm/AttestationCreateRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models.dtm;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -1,31 +1,3 @@
-/*
- * Copyright (c) 2015, Contrast Security, LLC.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are
- * permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials
- * provided with the distribution.
- *
- * Neither the name of the Contrast Security, LLC. nor the names of its contributors may
- * be used to endorse or promote products derived from this software without specific
- * prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.contrastsecurity.sdk;
 
 /*-

--- a/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -32,7 +32,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/UserAgentProduct.java
+++ b/src/main/java/com/contrastsecurity/sdk/UserAgentProduct.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/UserAgentProduct.java
+++ b/src/main/java/com/contrastsecurity/sdk/UserAgentProduct.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/GsonFactory.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/GsonFactory.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/GsonFactory.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/GsonFactory.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/Lists.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/Lists.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/Lists.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/Lists.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/Nullable.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/Nullable.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/Nullable.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/Nullable.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/Refreshable.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/Refreshable.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/Refreshable.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/Refreshable.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/URIBuilder.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/URIBuilder.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/internal/URIBuilder.java
+++ b/src/main/java/com/contrastsecurity/sdk/internal/URIBuilder.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifact.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifact.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifact.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifact.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClient.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClient.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifacts.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifacts.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifacts.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifacts.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactsImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactsImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactsImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactsImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Project.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Project.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Project.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Project.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectClient.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectClient.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectClientImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectClientImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectCreate.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectCreate.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectCreate.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectCreate.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Projects.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Projects.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Projects.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Projects.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectsImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectsImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectsImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectsImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectsQuery.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectsQuery.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ProjectsQuery.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ProjectsQuery.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Sample.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Sample.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Sample.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Sample.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Scan.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Scan.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Scan.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Scan.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanClient.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanClient.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanClientImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanClientImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanCreate.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanCreate.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanCreate.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanCreate.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanException.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanException.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanManager.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanManager.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanManager.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanManager.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanManagerImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanManagerImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanManagerImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanManagerImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanPagedResult.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanPagedResult.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanPagedResult.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanPagedResult.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanStatus.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanStatus.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanStatus.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanStatus.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryInner.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Scans.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Scans.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/Scans.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/Scans.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScansImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScansImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/ScansImpl.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/ScansImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/package-info.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/package-info.java
@@ -14,7 +14,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/sdk/scan/package-info.java
+++ b/src/main/java/com/contrastsecurity/sdk/scan/package-info.java
@@ -14,7 +14,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
+++ b/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
+++ b/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/utils/MetadataDeserializer.java
+++ b/src/main/java/com/contrastsecurity/utils/MetadataDeserializer.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/contrastsecurity/utils/MetadataDeserializer.java
+++ b/src/main/java/com/contrastsecurity/utils/MetadataDeserializer.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/EqualsAndHashcodeContract.java
+++ b/src/test/java/com/contrastsecurity/EqualsAndHashcodeContract.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/EqualsAndHashcodeContract.java
+++ b/src/test/java/com/contrastsecurity/EqualsAndHashcodeContract.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/GsonTest.java
+++ b/src/test/java/com/contrastsecurity/GsonTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/GsonTest.java
+++ b/src/test/java/com/contrastsecurity/GsonTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/PactConstants.java
+++ b/src/test/java/com/contrastsecurity/PactConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/PactConstants.java
+++ b/src/test/java/com/contrastsecurity/PactConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/TestDataConstants.java
+++ b/src/test/java/com/contrastsecurity/TestDataConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/TestDataConstants.java
+++ b/src/test/java/com/contrastsecurity/TestDataConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/exceptions/HttpResponseExceptionTest.java
+++ b/src/test/java/com/contrastsecurity/exceptions/HttpResponseExceptionTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/exceptions/HttpResponseExceptionTest.java
+++ b/src/test/java/com/contrastsecurity/exceptions/HttpResponseExceptionTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/exceptions/UnauthorizedExceptionTest.java
+++ b/src/test/java/com/contrastsecurity/exceptions/UnauthorizedExceptionTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/exceptions/UnauthorizedExceptionTest.java
+++ b/src/test/java/com/contrastsecurity/exceptions/UnauthorizedExceptionTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/http/ApplicationFilterFilterFormTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/ApplicationFilterFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/http/ApplicationFilterFilterFormTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/FilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/http/FilterFormTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/FilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/http/FilterFormTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/TraceFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/http/TraceFilterFormTest.java
@@ -3,7 +3,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/TraceFilterFormTest.java
+++ b/src/test/java/com/contrastsecurity/http/TraceFilterFormTest.java
@@ -3,7 +3,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/http/UrlBuilderTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/http/UrlBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/http/UrlBuilderTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/ContrastSDKTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/ContrastSDKTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/ContrastSDKTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/internal/URIBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/internal/URIBuilderTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/internal/URIBuilderTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/internal/URIBuilderTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsPactTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsPactTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ProjectAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ProjectAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ProjectAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ProjectAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ProjectsImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ProjectsImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ProjectsImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ProjectsImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ProjectsPactTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ProjectsPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ProjectsPactTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ProjectsPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanManagerImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanManagerImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanManagerImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanManagerImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScansImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScansImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScansImplTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScansImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScansPactTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScansPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/sdk/scan/ScansPactTest.java
+++ b/src/test/java/com/contrastsecurity/sdk/scan/ScansPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/utils/ContrastSDKUtilsTest.java
+++ b/src/test/java/com/contrastsecurity/utils/ContrastSDKUtilsTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2014 - 2022 Contrast Security, Inc.
+ * Copyright (C) 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/contrastsecurity/utils/ContrastSDKUtilsTest.java
+++ b/src/test/java/com/contrastsecurity/utils/ContrastSDKUtilsTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2021 Contrast Security, Inc.
+ * Copyright (C) 2014 - 2022 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Overview
This updates the copyright dates and allows the plugin to automatically make updates to the copyright section. This will automatically update the copyright dates in a new year. 

# Changes
1. Updated inceptionYear to be the same as when version 1.0 was released
2. Updated file headers
3. Updated license file
4. Allowed license plugin to make updates to the copyright section of the header

# Notes
The canUpdateCopyright is defaulted to false because the developer should be updating the copyright dates. https://www.mojohaus.org/license-maven-plugin/update-file-header-mojo.html#canUpdateCopyright. I think it is fine for us to set it to be true because the headers are updated only in the developer profile and we use PRs, so it will be difficult to accidentally update when you don't want it to. The alternative is to delete the headers in each file either by the `remove-file-header` goal or manually, and then rerun to update the header as a whole. 

There is a `update-project-file` https://www.mojohaus.org/license-maven-plugin/update-project-license-mojo.html to automatically update the license file but it had a bunch of stuff that I did not understand so I didn't touch it and just updated the LICENSE file manually.