### PR TITLE
JAVA-8967 update file headers for Lombok

### DIFF
--- a/sdk/src/main/java-templates/com/contrastsecurity/sdk/Version.java
+++ b/sdk/src/main/java-templates/com/contrastsecurity/sdk/Version.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/ApplicationCreateException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/ConfigurationException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/ConfigurationException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/ContrastException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/ContrastException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/HttpResponseException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/HttpResponseException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/InvalidConversionException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/ResourceNotFoundException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/ServerResponseException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/ServerResponseException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
+++ b/sdk/src/main/java/com/contrastsecurity/exceptions/UnauthorizedException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/ApplicationFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/FilterForm.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/FilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/HttpMethod.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/HttpMethod.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/JobOutcomePolicyListResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/LibraryFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/MediaType.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/MediaType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/RequestConstants.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/RequestConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/RequestUrlConstants.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/RequestUrlConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/RuleSeverity.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/RuleSeverity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/SecurityCheckFilter.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/SecurityCheckFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/SecurityCheckForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/SecurityCheckResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/ServerEnvironment.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/ServerEnvironment.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/ServerFilterForm.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/ServerFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/TraceFilterForm.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/TraceFilterForm.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/TraceFilterKeycode.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/TraceFilterKeycode.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/TraceFilterType.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/TraceFilterType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/http/UrlBuilder.java
+++ b/sdk/src/main/java/com/contrastsecurity/http/UrlBuilder.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/AgentType.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/AgentType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Application.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Application.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/ApplicationImportance.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/ApplicationImportance.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Applications.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Applications.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/AssessLicenseOverview.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/AssessLicenseOverview.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Card.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Card.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Chapter.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Chapter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/CodeObject.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/CodeObject.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Coverage.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Coverage.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/CustomRecommendation.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/CustomRecommendation.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/CustomRuleReferences.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/CustomRuleReferences.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Event.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Event.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/EventDetails.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/EventDetails.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/EventItem.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/EventItem.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/EventModel.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/EventModel.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/EventResource.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/EventResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/EventSummaryResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/EventSummaryResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/FreeformMetadata.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/FreeformMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/GenericResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/GenericResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/GlobalProperties.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/GlobalProperties.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/HttpRequest.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/HttpRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/HttpRequestResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/HttpRequestResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/JobOutcomePolicy.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/JobOutcomePolicySeverity.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/JobOutcomePolicySeverity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Libraries.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Libraries.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Library.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Library.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/LibraryScores.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/LibraryScores.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/LibraryStats.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/LibraryStats.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/LibraryVulnerability.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/LibraryVulnerability.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/License.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/License.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Login.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Login.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/MakeRequestResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/MakeRequestResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/MetadataEntity.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/MetadataEntity.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/MetadataFilterGroup.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/MetadataFilterGroup.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/MetadataFilterResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/MetadataFilterResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/MetadataFilterValue.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/MetadataFilterValue.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/NameValuePair.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/NameValuePair.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/NotificationResource.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/NotificationResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/NotificationsResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/NotificationsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/NumericMetadata.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/NumericMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Organization.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Organization.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Organizations.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Organizations.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Parameter.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Parameter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/PointOfContactMetadata.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/PointOfContactMetadata.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/PropertyResource.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/PropertyResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Recommendation.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Recommendation.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/RecommendationResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/RecommendationResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Risk.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Risk.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/RouteCoverageBySessionIDAndMetadataRequest.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/RouteCoverageBySessionIDAndMetadataRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/RouteCoverageMetadataLabelValues.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/RouteCoverageMetadataLabelValues.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/RouteCoverageResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/RuleReferences.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/RuleReferences.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Rules.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Rules.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/ScanPagedResult.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/ScanPagedResult.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Scores.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Scores.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/SecurityCheck.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/SecurityCheck.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Server.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Server.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/ServerTagsResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/ServerTagsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Servers.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Servers.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/SignUp.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/SignUp.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Stacktrace.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Stacktrace.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/StatusRequest.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/StatusRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Story.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Story.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/StoryResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/StoryResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Tag.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Tag.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Tags.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Tags.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TagsResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TagsResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Trace.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Trace.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceBreakdown.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceBreakdown.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceEvent.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceEvent.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceFilter.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceFilterBody.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceFilterBody.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceListing.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceListing.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceMetadataFilter.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceMetadataFilter.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceNote.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceNote.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceNoteResource.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceNoteResource.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceNotesResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceNotesResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TraceTimestampField.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TraceTimestampField.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Traces.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Traces.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/TracesWithResponse.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/URLEntry.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/URLEntry.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/User.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/User.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/Users.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/Users.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/VulnerabilityQuickFilterType.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/VulnerabilityQuickFilterType.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/VulnerabilityTrend.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/VulnerabilityTrend.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/dtm/ApplicationCreateRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models.dtm;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/models/dtm/AttestationCreateRequest.java
+++ b/sdk/src/main/java/com/contrastsecurity/models/dtm/AttestationCreateRequest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.models.dtm;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/ContrastSDK.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/UserAgentProduct.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/UserAgentProduct.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/internal/GsonFactory.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/internal/GsonFactory.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/internal/Lists.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/internal/Lists.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/internal/Nullable.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/internal/Nullable.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/internal/Refreshable.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/internal/Refreshable.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/internal/URIBuilder.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/internal/URIBuilder.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifact.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifact.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClient.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactInner.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifacts.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifacts.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactsImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/CodeArtifactsImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/Project.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/Project.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectClient.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectClientImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectCreate.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectCreate.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectInner.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/Projects.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/Projects.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectsImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectsImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectsQuery.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ProjectsQuery.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/Sample.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/Sample.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/Scan.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/Scan.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanClient.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanClient.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanClientImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanClientImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanCreate.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanCreate.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanException.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanException.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanInner.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanManager.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanManager.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanManagerImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanManagerImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanPagedResult.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanPagedResult.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanStatus.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanStatus.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanSummary.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryInner.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScanSummaryInner.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/Scans.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/Scans.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScansImpl.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/ScansImpl.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/sdk/scan/package-info.java
+++ b/sdk/src/main/java/com/contrastsecurity/sdk/scan/package-info.java
@@ -14,7 +14,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
+++ b/sdk/src/main/java/com/contrastsecurity/utils/ContrastSDKUtils.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/main/java/com/contrastsecurity/utils/MetadataDeserializer.java
+++ b/sdk/src/main/java/com/contrastsecurity/utils/MetadataDeserializer.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/EqualsAndHashcodeContract.java
+++ b/sdk/src/test/java/com/contrastsecurity/EqualsAndHashcodeContract.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/GsonTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/GsonTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/PactConstants.java
+++ b/sdk/src/test/java/com/contrastsecurity/PactConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/TestDataConstants.java
+++ b/sdk/src/test/java/com/contrastsecurity/TestDataConstants.java
@@ -4,7 +4,7 @@ package com.contrastsecurity;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/exceptions/HttpResponseExceptionTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/exceptions/HttpResponseExceptionTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/exceptions/UnauthorizedExceptionTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/exceptions/UnauthorizedExceptionTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.exceptions;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/http/ApplicationFilterFilterFormTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/http/ApplicationFilterFilterFormTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/http/FilterFormTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/http/FilterFormTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/http/TraceFilterFormTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/http/TraceFilterFormTest.java
@@ -3,7 +3,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/http/UrlBuilderTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/http/UrlBuilderTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.http;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/ContrastSDKTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/ContrastSDKTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/internal/URIBuilderTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/internal/URIBuilderTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.internal;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactAssert.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImplTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactClientImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsImplTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsPactTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/CodeArtifactsPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ProjectAssert.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ProjectAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ProjectsImplTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ProjectsImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ProjectsPactTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ProjectsPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanAssert.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanManagerImplTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanManagerImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryAssert.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryImplTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScanSummaryImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScansImplTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScansImplTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScansPactTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/sdk/scan/ScansPactTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.sdk.scan;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk/src/test/java/com/contrastsecurity/utils/ContrastSDKUtilsTest.java
+++ b/sdk/src/test/java/com/contrastsecurity/utils/ContrastSDKUtilsTest.java
@@ -4,7 +4,7 @@ package com.contrastsecurity.utils;
  * #%L
  * Contrast Java SDK
  * %%
- * Copyright (C) 2022 - 2024 Contrast Security, Inc.
+ * Copyright (C) 2022 - 2025 Contrast Security, Inc.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I spent an hour trying to figure out why lombok was failing mvn verify steps on my other pr, turns out it needed to _update the headers to say 2025_

Happy New Year Brian!