### PR TITLE
JAVA-9127 update task registration to never be up to date

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.3.1'
 }
 
-version = '3.0.0'
+version = '3.0.1'
 group = 'com.contrastsecurity.gradle.plugin'
 
 repositories {

--- a/gradle-plugin/src/main/java/com/contrastsecurity/gradle/plugin/ContrastGradlePlugin.java
+++ b/gradle-plugin/src/main/java/com/contrastsecurity/gradle/plugin/ContrastGradlePlugin.java
@@ -106,6 +106,9 @@ public class ContrastGradlePlugin implements Plugin<Project> {
                                 sdk);
                     verifyTask.configure(
                         v -> {
+
+                          // ensure task outputs are never up to date so the task always runs
+                          v.getOutputs().upToDateWhen(task -> false);
                           v.dependsOn(testTask);
 
                           // set output file for found vulnerabilities


### PR DESCRIPTION
Verify Test Tasks were being marked as `UP-TO-DATE` and not running if they passed once. Even running `clean` wouldn't cause them to rerun. Fixed by forcing this task to never be up to date. This is good anyway because we want to re-query the sdk every time we run tests or change the configuration anyway.