### PR TITLE
JAVA-8421 update maven release version

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.contrastsecurity</groupId>
   <artifactId>contrast-maven-plugin</artifactId>
-  <version>2.13.3</version>
+  <version>2.13.4-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Contrast Maven Plugin</name>


### PR DESCRIPTION
I think the only thing we need to do to get the release to work is keep this `SNAPSHOT` version here. I'm going to try to release the plugin again. Worst case scenario it fails, best case scenario the existing build stuff auto strips the `SNAPSHOT` and updates the version on its own, which is I think what it's supposed to do. 🤞 